### PR TITLE
Make install-cli compatible with dash on Linux

### DIFF
--- a/install-cli.sh
+++ b/install-cli.sh
@@ -28,7 +28,7 @@ validate_checksum() {
 
   checksum=$($checksumbin -a256 "${filename}")
 
-  if grep -Fxq "${checksum}" <<< "${checksumlist}"; then
+  if echo "${checksumlist}" | grep -Fxq "${checksum}"; then
     echo "Checksum valid."
     return 0
   else


### PR DESCRIPTION
The <<< redirection is not available on dash (/bin/sh)
on linux systems, which makes our script and instructions
broken.

Fixes #66 