### PR TITLE
Add promscale subcommand

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Lint
         working-directory: ${{env.working-directory}}
-        run:
+        run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
           golangci-lint run
 

--- a/cli/cmd/portForward.go
+++ b/cli/cmd/portForward.go
@@ -11,7 +11,7 @@ import (
 // portForwardCmd represents the port-forward command
 var portForwardCmd = &cobra.Command{
 	Use:   "port-forward",
-	Short: "Port-forwards TimescaleDB, Grafana, and Prometheus to localhost",
+	Short: "Port-forwards TimescaleDB, Promscale, Promlens, Grafana, and Prometheus to localhost",
 	Args:  cobra.ExactArgs(0),
 	RunE:  portForward,
 }
@@ -21,7 +21,7 @@ func init() {
 	portForwardCmd.Flags().IntP("timescaledb", "t", LISTEN_PORT_TSDB, "Port to listen from for TimescaleDB")
 	portForwardCmd.Flags().IntP("grafana", "g", LISTEN_PORT_GRAFANA, "Port to listen from for Grafana")
 	portForwardCmd.Flags().IntP("prometheus", "p", LISTEN_PORT_PROM, "Port to listen from for Prometheus")
-	portForwardCmd.Flags().IntP("connector", "c", LISTEN_PORT_CONNECTOR, "Port to listen from for the Connector")
+	portForwardCmd.Flags().IntP("promscale", "c", LISTEN_PORT_PROMSCALE, "Port to listen from for the Promscale")
 	portForwardCmd.Flags().IntP("promlens", "l", LISTEN_PORT_PROMLENS, "Port to listen from for PromLens")
 }
 
@@ -46,8 +46,8 @@ func portForward(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not port-forward: %w", err)
 	}
 
-	var connector int
-	connector, err = cmd.Flags().GetInt("connector")
+	var promscale int
+	promscale, err = cmd.Flags().GetInt("promscale")
 	if err != nil {
 		return fmt.Errorf("could not port-forward: %w", err)
 	}
@@ -95,7 +95,7 @@ func portForward(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := portForwardConnector(connector); err != nil {
+	if err := portForwardPromscale(promscale); err != nil {
 		return err
 	}
 	select {}

--- a/cli/cmd/promlens.go
+++ b/cli/cmd/promlens.go
@@ -4,10 +4,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// grafanaCmd represents the grafana command
+// promlensCmd represents the promlens command
 var promlensCmd = &cobra.Command{
 	Use:   "promlens",
-	Short: "Subcommand for Grafana operations",
+	Short: "Subcommand for Promlens operations",
 }
 
 func init() {

--- a/cli/cmd/promlensPortForward.go
+++ b/cli/cmd/promlensPortForward.go
@@ -10,13 +10,11 @@ import (
 
 const LISTEN_PORT_PROMLENS = 8081
 const FORWARD_PORT_PROMLENS = 8080
-const LISTEN_PORT_CONNECTOR = 9201
-const FORWARD_PORT_CONNECTOR = 9201
 
 // promlensPortForwardCmd represents the PromLens port-forward command
 var promlensPortForwardCmd = &cobra.Command{
 	Use:   "port-forward",
-	Short: "Port-forwards PromLens UI and connector to localhost",
+	Short: "Port-forwards PromLens UI to localhost",
 	Args:  cobra.ExactArgs(0),
 	RunE:  promlensPortForward,
 }
@@ -24,7 +22,6 @@ var promlensPortForwardCmd = &cobra.Command{
 func init() {
 	promlensCmd.AddCommand(promlensPortForwardCmd)
 	promlensPortForwardCmd.Flags().IntP("port", "p", LISTEN_PORT_PROMLENS, "Port to listen from for promlens")
-	promlensPortForwardCmd.Flags().IntP("port-connector", "c", LISTEN_PORT_CONNECTOR, "Port to listen for the connector")
 }
 
 func portForwardPromlens(listenPort int) error {
@@ -41,19 +38,6 @@ func portForwardPromlens(listenPort int) error {
 	return nil
 }
 
-func portForwardConnector(listenPort int) error {
-	serviceNameConnector, err := k8s.KubeGetServiceName(namespace, map[string]string{"release": name, "app": name + "-promscale"})
-	if err != nil {
-		return fmt.Errorf("could not port-forward PromLens: %w", err)
-	}
-
-	_, err = k8s.KubePortForwardService(namespace, serviceNameConnector, listenPort, FORWARD_PORT_CONNECTOR)
-	if err != nil {
-		return fmt.Errorf("could not port-forward PromLens: %w", err)
-	}
-
-	return nil
-}
 
 func promlensPortForward(cmd *cobra.Command, args []string) error {
 	var err error
@@ -64,17 +48,7 @@ func promlensPortForward(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not port-forward PromLens: %w", err)
 	}
 
-	var portConnector int
-	portConnector, err = cmd.Flags().GetInt("port-connector")
-	if err != nil {
-		return fmt.Errorf("could not port-forward PromLens: %w", err)
-	}
-
 	if err := portForwardPromlens(port); err != nil {
-		return err
-	}
-
-	if err := portForwardConnector(portConnector); err != nil {
 		return err
 	}
 

--- a/cli/cmd/promscale.go
+++ b/cli/cmd/promscale.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+"github.com/spf13/cobra"
+)
+
+// promscaleCmd represents the promscale command
+var promscaleCmd = &cobra.Command{
+	Use:   "promscale",
+	Short: "Subcommand for Promscale operations",
+}
+
+func init() {
+	rootCmd.AddCommand(promscaleCmd)
+}
+

--- a/cli/cmd/promscalePortForward.go
+++ b/cli/cmd/promscalePortForward.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/timescale/tobs/cli/pkg/k8s"
+)
+
+const LISTEN_PORT_PROMSCALE = 9201
+const FORWARD_PORT_PROMSCALE = 9201
+
+// promscalePortForwardCmd represents the PromScale port-forward command
+var promscalePortForwardCmd = &cobra.Command{
+	Use:   "port-forward",
+	Short: "Port-forwards Promscale to localhost",
+	Args:  cobra.ExactArgs(0),
+	RunE:  promscalePortForward,
+}
+
+func init() {
+	promscaleCmd.AddCommand(promscalePortForwardCmd)
+	promscalePortForwardCmd.Flags().IntP("port", "p", LISTEN_PORT_PROMSCALE, "Port to listen for the promscale")
+}
+
+func portForwardPromscale(listenPort int) error {
+	serviceNamePromscale, err := k8s.KubeGetServiceName(namespace, map[string]string{"release": name, "app": name + "-promscale"})
+	if err != nil {
+		return fmt.Errorf("could not port-forward Promscale: %w", err)
+	}
+
+	_, err = k8s.KubePortForwardService(namespace, serviceNamePromscale, listenPort, FORWARD_PORT_PROMSCALE)
+	if err != nil {
+		return fmt.Errorf("could not port-forward Promscale: %w", err)
+	}
+
+	return nil
+}
+
+func promscalePortForward(cmd *cobra.Command, args []string) error {
+	var err error
+
+	var port int
+	port, err = cmd.Flags().GetInt("port")
+	if err != nil {
+		return fmt.Errorf("could not port-forward Promscale: %w", err)
+	}
+
+	if err := portForwardPromscale(port); err != nil {
+		return err
+	}
+
+	select {}
+}

--- a/cli/tests/concurrent_test.go
+++ b/cli/tests/concurrent_test.go
@@ -31,7 +31,9 @@ func TestConcurrent(t *testing.T) {
 	}
 
 	// skipping concurrent tests for now
-	t.Skip("Skipping concurrent tests as it needs changes on multiple tobs installations on the same cluster.")
+	if true {
+		t.Skip("Skipping concurrent tests as it needs changes on multiple tobs installations on the same cluster.")
+	}
 
 	testUninstall(t, "", "", false)
 

--- a/cli/tests/portforward_test.go
+++ b/cli/tests/portforward_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func testpf(t testing.TB, timescale, grafana, prometheus, connector, promlens string) {
+func testpf(t testing.TB, timescale, grafana, prometheus, promscale, promlens string) {
 	cmds := []string{"port-forward", "-n", RELEASE_NAME, "--namespace", NAMESPACE}
 	if timescale != "" {
 		cmds = append(cmds, "-t", timescale)
@@ -20,8 +20,8 @@ func testpf(t testing.TB, timescale, grafana, prometheus, connector, promlens st
 	if prometheus != "" {
 		cmds = append(cmds, "-p", prometheus)
 	}
-	if connector != "" {
-		cmds = append(cmds, "-c", connector)
+	if promscale != "" {
+		cmds = append(cmds, "-c", promscale)
 	}
 	if promlens != "" {
 		cmds = append(cmds, "-l", promlens)
@@ -45,8 +45,8 @@ func testpf(t testing.TB, timescale, grafana, prometheus, connector, promlens st
 	if prometheus == "" {
 		prometheus = "9090"
 	}
-	if connector == "" {
-		connector = "9201"
+	if promscale == "" {
+		promscale = "9201"
 	}
 	if promlens == "" {
 		promlens = "8081"
@@ -64,7 +64,7 @@ func testpf(t testing.TB, timescale, grafana, prometheus, connector, promlens st
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = net.DialTimeout("tcp", "localhost:"+connector, 2*time.Second)
+	_, err = net.DialTimeout("tcp", "localhost:"+promscale, 2*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/tests/promlens_test.go
+++ b/cli/tests/promlens_test.go
@@ -9,13 +9,10 @@ import (
 	"time"
 )
 
-func testPromlensPortForward(t testing.TB, portPromlens, portConnector string) {
+func testPromlensPortForward(t testing.TB, portPromlens string) {
 	cmds := []string{"promlens", "port-forward", "-n", RELEASE_NAME, "--namespace", NAMESPACE}
 	if portPromlens != "" {
 		cmds = append(cmds, "-p", portPromlens)
-	}
-	if portConnector != "" {
-		cmds = append(cmds, "-c", portConnector)
 	}
 
 	t.Logf("Running '%v'", "tobs "+strings.Join(cmds, " "))
@@ -32,19 +29,12 @@ func testPromlensPortForward(t testing.TB, portPromlens, portConnector string) {
 		portPromlens = "8081"
 	}
 
-	if portConnector == "" {
-		portConnector = "9201"
-	}
 
 	_, err = net.DialTimeout("tcp", "localhost:"+portPromlens, 2*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = net.DialTimeout("tcp", "localhost:"+portConnector, 2*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	err = portforward.Process.Signal(syscall.SIGINT)
 	if err != nil {
@@ -54,9 +44,9 @@ func testPromlensPortForward(t testing.TB, portPromlens, portConnector string) {
 
 func TestPromlens(t *testing.T) {
 	if testing.Short() {
-		t.Skip("Skipping Grafana tests")
+		t.Skip("Skipping Promlens tests")
 	}
 
-	testPromlensPortForward(t, "", "")
-	testPromlensPortForward(t, "1235", "3421")
+	testPromlensPortForward(t, "")
+	testPromlensPortForward(t, "1235")
 }

--- a/cli/tests/promscale_test.go
+++ b/cli/tests/promscale_test.go
@@ -1,0 +1,53 @@
+package tests
+
+import (
+	"net"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func testPromscalePortForward(t testing.TB, portPromscale string) {
+	cmds := []string{"promscale", "port-forward", "-n", RELEASE_NAME, "--namespace", NAMESPACE}
+
+	if portPromscale != "" {
+		cmds = append(cmds, "-p", portPromscale)
+	}
+
+	t.Logf("Running '%v'", "tobs "+strings.Join(cmds, " "))
+	portforward := exec.Command("./../bin/tobs", cmds...)
+
+	err := portforward.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(10 * time.Second)
+
+
+	if portPromscale == "" {
+		portPromscale = "9201"
+	}
+
+	_, err = net.DialTimeout("tcp", "localhost:"+portPromscale, 2*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = portforward.Process.Signal(syscall.SIGINT)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPromscale(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping Promscale tests")
+	}
+
+	testPromscalePortForward(t, "")
+	testPromscalePortForward(t, "3421")
+}
+


### PR DESCRIPTION
1. Separated promscale from promlens subcommand along with e2e tests.
2. Refactored code, flags from `connector` to `promscale`

Signed-off-by: Vineeth Pothulapati <vineethpothulapati@outlook.com>