### PR TITLE
README: releases link might give 404

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -16,7 +16,7 @@ To download and install tobs, run the following in your terminal, then follow th
 curl --proto '=https' --tlsv1.2 -sSLf  https://tsdb.co/install-tobs-sh |sh
 ```
 
-Alternatively, you can download the CLI directly via [our releases page](/releases)
+Alternatively, you can download the CLI directly via [our releases page](https://github.com/timescale/tobs/releases/latest)
 
 ### Using the tobs CLI tool to deploy the stack into your Kubernetes cluster
 


### PR DESCRIPTION
maybe depending on how you reach the README.md, but the releases link is giving a 404 when using the link on "https://github.com/timescale/tobs" page, so replace it with full link

Second part of the diff is caused by doing a 'github' edit I guess, I don't see the diff on that line...