### PR TITLE
tobs-cli: respect default kubeconfig loading rules

### DIFF
--- a/cli/pkg/k8s/k8s.go
+++ b/cli/pkg/k8s/k8s.go
@@ -29,8 +29,10 @@ var HOME = os.Getenv("HOME")
 func kubeInit() (kubernetes.Interface, *rest.Config) {
 	var err error
 
+    loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: HOME + "/.kube/config"},
+		loadingRules,
 		&clientcmd.ConfigOverrides{}).ClientConfig()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
so e.g. export KUBECONFIG=path/to/some/kubeconfig is respected

fixes #94 