### PR TITLE
exec helm Combined Stderr&Stdout problem for show-values

### DIFF
--- a/cli/cmd/helmShowValues.go
+++ b/cli/cmd/helmShowValues.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 
 	"github.com/spf13/cobra"
@@ -28,9 +29,10 @@ func helmShowValues(cmd *cobra.Command, args []string) error {
 	} else {
 		showvalues = exec.Command("helm", "show", "values", "timescale/tobs")
 	}
+	showvalues.Stderr = os.Stderr
 
 	var out []byte
-	out, err = showvalues.CombinedOutput()
+	out, err = showvalues.Output()
 	if err != nil {
 		return fmt.Errorf("could not get Helm values: %w", err)
 	}

--- a/cli/pkg/k8s/k8s.go
+++ b/cli/pkg/k8s/k8s.go
@@ -29,8 +29,10 @@ var HOME = os.Getenv("HOME")
 func kubeInit() (kubernetes.Interface, *rest.Config) {
 	var err error
 
+    loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: HOME + "/.kube/config"},
+		loadingRules,
 		&clientcmd.ConfigOverrides{}).ClientConfig()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Don't use exec.Cmd.CombinedOutput() when execing as it makes redirection to yaml file prone to silent failures

> *NOTE:* this is not a fix for #96, just for the additional issue that the Helm Stderr pollutes the Stdout that is directed into the values.yaml

```
sven@x1carbon:~/src/github/timescaledb/tobs/cli$ tobs helm show-values | head
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /etc/rancher/k3s/k3s.yaml
# Values for configuring the deployment of TimescaleDB
# The charts README is at:
#    https://github.com/timescale/timescaledb-kubernetes/tree/master/charts/timescaledb-single
# Check out the various configuration options (administration guide) at:
#    https://github.com/timescale/timescaledb-kubernetes/blob/master/charts/timescaledb-single/admin-guide.md
cli: false
timescaledb-single:
  # disable the chart if an existing TimescaleDB instance is used
  enabled: true
sven@x1carbon:~/src/github/timescaledb/tobs/cli$ ./bin/tobs helm show-values > /tmp/values.yaml| head
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /etc/rancher/k3s/k3s.yaml

```