### PR TITLE
Change alertmanager kubernetes_sd_config labels

### DIFF
--- a/chart/templates/prometheus-conf.yaml
+++ b/chart/templates/prometheus-conf.yaml
@@ -81,8 +81,8 @@ data:
         - source_labels: [__meta_kubernetes_namespace]
           regex: {{ $root.Release.Namespace }}
           action: keep
-        - source_labels: [__meta_kubernetes_pod_label_app]
-          regex: {{ template "prometheus.name" $root }}
+        - source_labels: [__meta_kubernetes_pod_label_release]
+          regex: {{ $root.Release.Name }}
           action: keep
         - source_labels: [__meta_kubernetes_pod_label_component]
           regex: alertmanager


### PR DESCRIPTION
Hi.
I've also been unable to get alertmanager working with this helm chart. (see #99 )

By default, the alertmanger API endpoint discovery is disabled due to a target error in prometheus.yml during alertmanger communication.

I changed source_labels in prometheus.yml. So, It seems to be working well.



