### PR TITLE
Update Prometheus config

### DIFF
--- a/chart/templates/prometheus-conf.yaml
+++ b/chart/templates/prometheus-conf.yaml
@@ -20,7 +20,7 @@ data:
 {{- if $root.Values.prometheus.server.timescaleRemote.write.enabled -}}
 {{ with $root.Values.prometheus.server.timescaleRemote }}
     - url: {{ printf "%s://%s:%s/%s" .protocol (tpl .host $root) .port .write.endpoint }}
-      queue_config: 
+      queue_config:
 {{ toYaml .write.queue | indent 8 }}
 {{- end -}}
 {{- end }}
@@ -91,8 +91,8 @@ data:
           regex: {{ index $root.Values.prometheus.alertmanager.podAnnotations "prometheus.io/probe" | default ".*" }}
           action: keep
         - source_labels: [__meta_kubernetes_pod_container_port_number]
-          regex:
-          action: drop
+          regex: "9093"
+          action: keep
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
update Prometheus config according to the upstream Prometheus helm chart fix on alert-manager port config.
This PR addresses two things:
1. In tobs we follow the default Prometheus configuration from the Prometheus helm chart. There is alertManager port level update for alertManager service discovery. Here is the upstream merged [PR](https://github.com/prometheus-community/helm-charts/pull/353). In this PR we added the same fix to tobs Prometheus config. 
2. Viewing & editing the Prometheus config file in tobs was a bit messy previously as configmap YAML parsing was shrinking the Prometheus config into string due to trailing whitespaces, fixed it in this PR. Now users can interact with Prometheus config with much ease. 

Before:
```
  prometheus.yml: "global:\n  evaluation_interval: 1m\n  scrape_interval: 1m\n  scrape_timeout:
    10s\nremote_write:\n- url: http://tobs-promscale-connector.default.svc.cluster.local:9201/write\n
    \ queue_config: \n    max_shards: 30\n\nremote_read:\n- url: http://tobs-promscale-connector.default.svc.cluster.local:9201/read\n
    \ read_recent: true\n\nrule_files:\n- /etc/config/recording_rules.yml\n- /etc/config/alerting_rules.yml\n-

```
After:
```
  prometheus.yml: |
    global:
      evaluation_interval: 1m
      scrape_interval: 1m
      scrape_timeout: 10s
    remote_write:
    - url: http://tobs-promscale-connector.default.svc.cluster.local:9201/write
      queue_config:
        max_shards: 30
      ....
```