### PR TITLE
fix tobs uninstall flow

### DIFF
--- a/cli/cmd/helm/delete_data.go
+++ b/cli/cmd/helm/delete_data.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	root "github.com/timescale/tobs/cli/cmd"
+	"github.com/timescale/tobs/cli/cmd/common"
 	"github.com/timescale/tobs/cli/pkg/k8s"
 )
 
@@ -13,14 +14,14 @@ var helmDeleteDataCmd = &cobra.Command{
 	Use:   "delete-data",
 	Short: "Deletes Persistent Volume Claims",
 	Args:  cobra.ExactArgs(0),
-	RunE:  helmDeleteData,
+	RunE:  deletePVCData,
 }
 
 func init() {
 	helmCmd.AddCommand(helmDeleteDataCmd)
 }
 
-func helmDeleteData(cmd *cobra.Command, args []string) error {
+func deletePVCData(cmd *cobra.Command, args []string) error {
 	var err error
 
 	fmt.Println("Getting Persistent Volume Claims")
@@ -29,6 +30,13 @@ func helmDeleteData(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("could not delete PVCs: %w", err)
 	}
+
+	// Prometheus PVC's doesn't hold the release labelSet
+	prometheusPvcNames, err := k8sClient.KubeGetPVCNames(root.Namespace, common.GetPrometheusLabels())
+	if err != nil {
+		return fmt.Errorf("could not uninstall The Observability Stack: %w", err)
+	}
+	pvcnames = append(pvcnames, prometheusPvcNames...)
 
 	fmt.Println("Removing Persistent Volume Claims")
 	for _, s := range pvcnames {


### PR DESCRIPTION
1. Removed the duplicate code
2. Added additional secret deletion which isn't deleted on performing helm chart uninstall. 