### PR TITLE
Refactor tobs timescaledb & metrics cmds

### DIFF
--- a/cli/cmd/metrics/chunk_interval_get.go
+++ b/cli/cmd/metrics/chunk_interval_get.go
@@ -27,7 +27,7 @@ func chunkIntervalGet(cmd *cobra.Command, args []string) error {
 
 	metric := args[0]
 
-	d, err := common.FormDBDetails(user, dbname, root.Namespace, root.HelmReleaseName)
+	d, err := common.GetSuperuserDBDetails(root.Namespace, root.HelmReleaseName)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/metrics/chunk_interval_reset.go
+++ b/cli/cmd/metrics/chunk_interval_reset.go
@@ -26,7 +26,7 @@ func chunkIntervalReset(cmd *cobra.Command, args []string) error {
 
 	metric := args[0]
 
-	d, err := common.FormDBDetails(user, dbname, root.Namespace, root.HelmReleaseName)
+	d, err := common.GetSuperuserDBDetails(root.Namespace, root.HelmReleaseName)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/metrics/chunk_interval_set.go
+++ b/cli/cmd/metrics/chunk_interval_set.go
@@ -37,7 +37,7 @@ func chunkIntervalSet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not set chunk interval for %v: %w", metric, errors.New("Chunk interval must be at least 1 minute"))
 	}
 
-	d, err := common.FormDBDetails(user, dbname, root.Namespace, root.HelmReleaseName)
+	d, err := common.GetSuperuserDBDetails(root.Namespace, root.HelmReleaseName)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/metrics/chunk_interval_set_default.go
+++ b/cli/cmd/metrics/chunk_interval_set_default.go
@@ -36,7 +36,7 @@ func chunkIntervalSetDefault(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not set default chunk interval: %w", errors.New("Chunk interval must be at least 1 minute"))
 	}
 
-	d, err := common.FormDBDetails(user, dbname, root.Namespace, root.HelmReleaseName)
+	d, err := common.GetSuperuserDBDetails(root.Namespace, root.HelmReleaseName)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/metrics/metrics.go
+++ b/cli/cmd/metrics/metrics.go
@@ -7,29 +7,14 @@ import (
 	root "github.com/timescale/tobs/cli/cmd"
 )
 
-var user string
-var dbname string
-
 // metricsCmd represents the metrics command
 var metricsCmd = &cobra.Command{
 	Use:   "metrics",
 	Short: "Subcommand for metrics operations",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		var err error
-
-		err = root.RootCmd.PersistentPreRunE(cmd, args)
+		err := root.RootCmd.PersistentPreRunE(cmd, args)
 		if err != nil {
 			return fmt.Errorf("could not read global flag: %w", err)
-		}
-
-		user, err = cmd.Flags().GetString("user")
-		if err != nil {
-			return fmt.Errorf("could not read flag: %w", err)
-		}
-
-		dbname, err = cmd.Flags().GetString("dbname")
-		if err != nil {
-			return fmt.Errorf("could not read flag: %w", err)
 		}
 
 		return nil
@@ -38,6 +23,4 @@ var metricsCmd = &cobra.Command{
 
 func init() {
 	root.RootCmd.AddCommand(metricsCmd)
-	metricsCmd.PersistentFlags().StringP("user", "U", "", "database user name")
-	metricsCmd.PersistentFlags().StringP("dbname", "d", "postgres", "database name to connect to")
 }

--- a/cli/cmd/metrics/retention_get.go
+++ b/cli/cmd/metrics/retention_get.go
@@ -26,7 +26,7 @@ func retentionGet(cmd *cobra.Command, args []string) error {
 
 	metric := args[0]
 
-	d, err := common.FormDBDetails(user, dbname, root.Namespace, root.HelmReleaseName)
+	d, err := common.GetSuperuserDBDetails(root.Namespace, root.HelmReleaseName)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/metrics/retention_reset.go
+++ b/cli/cmd/metrics/retention_reset.go
@@ -26,7 +26,7 @@ func retentionReset(cmd *cobra.Command, args []string) error {
 
 	metric := args[0]
 
-	d, err := common.FormDBDetails(user, dbname, root.Namespace, root.HelmReleaseName)
+	d, err := common.GetSuperuserDBDetails(root.Namespace, root.HelmReleaseName)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/metrics/retention_set.go
+++ b/cli/cmd/metrics/retention_set.go
@@ -27,7 +27,7 @@ func retentionSet(cmd *cobra.Command, args []string) error {
 	metric := args[0]
 	retention_period := args[1]
 
-	d, err := common.FormDBDetails(user, dbname, root.Namespace, root.HelmReleaseName)
+	d, err := common.GetSuperuserDBDetails(root.Namespace, root.HelmReleaseName)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/metrics/retention_set_default.go
+++ b/cli/cmd/metrics/retention_set_default.go
@@ -26,7 +26,7 @@ func retentionSetDefault(cmd *cobra.Command, args []string) error {
 
 	retention_period := args[0]
 
-	d, err := common.FormDBDetails(user, dbname, root.Namespace, root.HelmReleaseName)
+	d, err := common.GetSuperuserDBDetails(root.Namespace, root.HelmReleaseName)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/timescaledb/port_forward.go
+++ b/cli/cmd/timescaledb/port_forward.go
@@ -18,7 +18,7 @@ var timescaledbPortForwardCmd = &cobra.Command{
 }
 
 func init() {
-	timescaledbCmd.AddCommand(timescaledbPortForwardCmd)
+	Cmd.AddCommand(timescaledbPortForwardCmd)
 	timescaledbPortForwardCmd.Flags().IntP("port", "p", common.LISTEN_PORT_TSDB, "Port to listen from")
 }
 

--- a/cli/cmd/timescaledb/superuser/connect.go
+++ b/cli/cmd/timescaledb/superuser/connect.go
@@ -1,0 +1,39 @@
+package superuser
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	root "github.com/timescale/tobs/cli/cmd"
+	"github.com/timescale/tobs/cli/cmd/common"
+	"github.com/timescale/tobs/cli/cmd/timescaledb"
+	"github.com/timescale/tobs/cli/pkg/k8s"
+)
+
+// timescaledbConnectCmd represents the timescaledb superuser connect command
+var timescaledbConnectCmd = &cobra.Command{
+	Use:   "connect",
+	Short: "Connects to the TimescaleDB database using super-user",
+	Args:  cobra.ExactArgs(0),
+	RunE:  Connect,
+}
+
+func init() {
+	superuserCmd.AddCommand(timescaledbConnectCmd)
+	timescaledbConnectCmd.Flags().BoolP("master", "m", false, "directly execute session on master node")
+}
+
+func Connect(cmd *cobra.Command, args []string) error {
+	master, err := cmd.Flags().GetBool("master")
+	if err != nil {
+		return fmt.Errorf("could not connect to TimescaleDB: %w", err)
+	}
+
+	dbDetails, err := common.GetSuperuserDBDetails(root.Namespace, root.HelmReleaseName)
+	if err != nil {
+		return fmt.Errorf("could not get DB secret key from helm release: %w", err)
+	}
+
+	k8sClient := k8s.NewClient()
+	return timescaledb.PsqlConnect(k8sClient, dbDetails, master)
+}

--- a/cli/cmd/timescaledb/superuser/get_password.go
+++ b/cli/cmd/timescaledb/superuser/get_password.go
@@ -1,9 +1,8 @@
-package timescaledb
+package superuser
 
 import (
 	"errors"
 	"fmt"
-
 	"github.com/spf13/cobra"
 	root "github.com/timescale/tobs/cli/cmd"
 	"github.com/timescale/tobs/cli/cmd/common"
@@ -19,7 +18,7 @@ var timescaledbGetPasswordCmd = &cobra.Command{
 }
 
 func init() {
-	timescaledbCmd.AddCommand(timescaledbGetPasswordCmd)
+	superuserCmd.AddCommand(timescaledbGetPasswordCmd)
 }
 
 func timescaledbGetPassword(cmd *cobra.Command, args []string) error {
@@ -31,7 +30,7 @@ func timescaledbGetPassword(cmd *cobra.Command, args []string) error {
 
 	var pass string
 
-	d, err := common.FormDBDetails(user, "", root.Namespace, root.HelmReleaseName)
+	d, err := common.GetSuperuserDBDetails(root.Namespace, root.HelmReleaseName)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/timescaledb/superuser/superuser.go
+++ b/cli/cmd/timescaledb/superuser/superuser.go
@@ -1,16 +1,17 @@
-package timescaledb
+package superuser
 
 import (
 	"fmt"
 
 	"github.com/spf13/cobra"
 	root "github.com/timescale/tobs/cli/cmd"
+	"github.com/timescale/tobs/cli/cmd/timescaledb"
 )
 
-// Cmd represents the timescaledb command
-var Cmd = &cobra.Command{
-	Use:   "timescaledb",
-	Short: "Subcommand for TimescaleDB operations",
+// Cmd represents the timescaledb superuser command
+var superuserCmd = &cobra.Command{
+	Use:   "superuser",
+	Short: "Subcommand for TimescaleDB super-user operations",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		err := root.RootCmd.PersistentPreRunE(cmd, args)
 		if err != nil {
@@ -22,5 +23,5 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	root.RootCmd.AddCommand(Cmd)
+	timescaledb.Cmd.AddCommand(superuserCmd)
 }

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	root "github.com/timescale/tobs/cli/cmd"
+	"github.com/timescale/tobs/cli/cmd/common"
 	"github.com/timescale/tobs/cli/cmd/install"
 	"github.com/timescale/tobs/cli/pkg/helm"
 	"github.com/timescale/tobs/cli/pkg/k8s"
@@ -351,9 +352,9 @@ func (c *upgradeSpec) copyDBSecret() error {
 			Labels:    utils.GetTimescaleDBsecretLabels(root.HelmReleaseName),
 		},
 		Data: map[string][]byte{
-			"PATRONI_REPLICATION_PASSWORD": standby,
-			"PATRONI_admin_PASSWORD":       admin,
-			"PATRONI_SUPERUSER_PASSWORD":   postgres,
+			common.DBReplicationSecretKey: standby,
+			common.DBAdminSecretKey:       admin,
+			common.DBSuperUserSecretKey:   postgres,
 		},
 		Type: "Opaque",
 	}

--- a/cli/main.go
+++ b/cli/main.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/timescale/tobs/cli/cmd/promlens"
 	_ "github.com/timescale/tobs/cli/cmd/promscale"
 	_ "github.com/timescale/tobs/cli/cmd/timescaledb"
+	_ "github.com/timescale/tobs/cli/cmd/timescaledb/superuser"
 	_ "github.com/timescale/tobs/cli/cmd/uninstall"
 	_ "github.com/timescale/tobs/cli/cmd/upgrade"
 	_ "github.com/timescale/tobs/cli/cmd/version"

--- a/cli/pkg/pgconn/connection.go
+++ b/cli/pkg/pgconn/connection.go
@@ -14,12 +14,13 @@ import (
 )
 
 type DBDetails struct {
-	Namespace string
-	Name      string
-	DBName    string
-	User      string
-	SecretKey string
-	Remote    int
+	Namespace   string
+	ReleaseName string
+	DBName      string
+	User        string
+	SecretKey   string
+	Password    string
+	Remote      int
 }
 
 func (d *DBDetails) OpenConnectionToDB() (*pgxpool.Pool, error) {
@@ -32,12 +33,12 @@ func (d *DBDetails) OpenConnectionToDB() (*pgxpool.Pool, error) {
 	defer func() { os.Stdout = stdout }()
 
 	k8sClient := k8s.NewClient()
-	tspromPods, err := k8sClient.KubeGetPods(d.Namespace, map[string]string{"app": d.Name + "-promscale"})
+	tspromPods, err := k8sClient.KubeGetPods(d.Namespace, map[string]string{"app": d.ReleaseName + "-promscale"})
 	if err != nil {
 		return nil, err
 	}
 
-	passBytes, err := utils.GetDBPassword(k8sClient, d.SecretKey, d.Name, d.Namespace)
+	passBytes, err := utils.GetDBPassword(k8sClient, d.SecretKey, d.ReleaseName, d.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -56,12 +57,12 @@ func (d *DBDetails) OpenConnectionToDB() (*pgxpool.Pool, error) {
 		}
 	}
 
-	dbURI, err := utils.GetTimescaleDBURI(k8sClient, d.Namespace, d.Name)
+	dbURI, err := utils.GetTimescaleDBURI(k8sClient, d.Namespace, d.ReleaseName)
 	if err != nil {
 		return nil, err
 	}
 
-	tsdbPods, err := k8sClient.KubeGetPods(d.Namespace, map[string]string{"release": d.Name, "role": "master"})
+	tsdbPods, err := k8sClient.KubeGetPods(d.Namespace, map[string]string{"release": d.ReleaseName, "role": "master"})
 	if err != nil {
 		return nil, err
 	}

--- a/cli/pkg/timescaledb_secrets/create.go
+++ b/cli/pkg/timescaledb_secrets/create.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/timescale/tobs/cli/cmd/common"
 	"github.com/timescale/tobs/cli/pkg/k8s"
 	"github.com/timescale/tobs/cli/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -110,9 +111,9 @@ func (t *TSDBSecretsInfo) createTimescaleDBCredentials() error {
 			Labels:    utils.GetTimescaleDBsecretLabels(t.ReleaseName),
 		},
 		Data: map[string][]byte{
-			"PATRONI_REPLICATION_PASSWORD": repPass,
-			"PATRONI_admin_PASSWORD":       adminPass,
-			"PATRONI_SUPERUSER_PASSWORD":   superUserPass,
+			common.DBReplicationSecretKey: repPass,
+			common.DBAdminSecretKey:       adminPass,
+			common.DBSuperUserSecretKey:   superUserPass,
 		},
 		Type: "Opaque",
 	}

--- a/cli/tests/external-db-tests/main_test.go
+++ b/cli/tests/external-db-tests/main_test.go
@@ -77,7 +77,7 @@ func runTobsWithoutTSDB() {
 
 	fmt.Printf("Created nodeport service for timescaleDB, connecting using ip %s\n", ip)
 
-	cmds := []string{"timescaledb", "get-password", "-n", "external-db-tests"}
+	cmds := []string{"timescaledb", "superuser", "get-password", "-n", "external-db-tests"}
 	getpass := exec.Command(PATH_TO_TOBS, cmds...)
 
 	out, err := getpass.CombinedOutput()

--- a/cli/tests/test-utils/common_utils.go
+++ b/cli/tests/test-utils/common_utils.go
@@ -16,12 +16,8 @@ type ReleaseInfo struct {
 	Namespace string
 }
 
-func (r *ReleaseInfo) TestTimescaleGetPassword(t testing.TB, user string) {
-	cmds := []string{"timescaledb", "get-password", "-n", r.Release, "--namespace", r.Namespace}
-	if user != "" {
-		cmds = append(cmds, "-U", user)
-	}
-
+func (r *ReleaseInfo) TestTimescaleGetPassword(t testing.TB) {
+	cmds := []string{"timescaledb", "superuser", "get-password", "-n", r.Release, "--namespace", r.Namespace}
 	t.Logf("Running '%v'", "tobs "+strings.Join(cmds, " "))
 	getpass := exec.Command(PATH_TO_TOBS, cmds...)
 
@@ -32,15 +28,8 @@ func (r *ReleaseInfo) TestTimescaleGetPassword(t testing.TB, user string) {
 	}
 }
 
-func (r *ReleaseInfo) TestTimescaleChangePassword(t testing.TB, user, dbname, newpass string) {
-	cmds := []string{"timescaledb", "change-password", newpass, "-n", r.Release, "--namespace", r.Namespace}
-	if user != "" {
-		cmds = append(cmds, "-U", user)
-	}
-	if dbname != "" {
-		cmds = append(cmds, "-d", dbname)
-	}
-
+func (r *ReleaseInfo) TestTimescaleChangePassword(t testing.TB, newpass string) {
+	cmds := []string{"timescaledb", "superuser", "change-password", newpass, "-n", r.Release, "--namespace", r.Namespace}
 	t.Logf("Running '%v'", "tobs "+strings.Join(cmds, " "))
 	changepass := exec.Command(PATH_TO_TOBS, cmds...)
 
@@ -51,8 +40,8 @@ func (r *ReleaseInfo) TestTimescaleChangePassword(t testing.TB, user, dbname, ne
 	}
 }
 
-func (r *ReleaseInfo) VerifyTimescalePassword(t testing.TB, user string, expectedPass string) {
-	getpass := exec.Command(PATH_TO_TOBS, "timescaledb", "get-password", "-U", user, "-n", r.Release, "--namespace", r.Namespace)
+func (r *ReleaseInfo) VerifyTimescalePassword(t testing.TB, expectedPass string) {
+	getpass := exec.Command(PATH_TO_TOBS, "timescaledb", "superuser", "get-password", "-n", r.Release, "--namespace", r.Namespace)
 
 	out, err := getpass.CombinedOutput()
 	if err != nil {
@@ -100,15 +89,32 @@ func (r *ReleaseInfo) TestTimescaleConnect(t testing.TB, master bool, user strin
 
 	if master {
 		t.Logf("Running 'tobs timescaledb connect -m'")
-		connect = exec.Command(PATH_TO_TOBS, "timescaledb", "connect", "-m", "-n", r.Release, "--namespace", r.Namespace)
+		connect = exec.Command(PATH_TO_TOBS, "timescaledb", "connect", user, "-m", "-n", r.Release, "--namespace", r.Namespace)
 	} else {
-		if user == "" {
-			t.Logf("Running 'tobs timescaledb connect'")
-			connect = exec.Command(PATH_TO_TOBS, "timescaledb", "connect", "-n", r.Release, "--namespace", r.Namespace)
-		} else {
-			t.Logf("Running 'tobs timescaledb connect -U %v'", user)
-			connect = exec.Command(PATH_TO_TOBS, "timescaledb", "connect", "-U", user, "-n", r.Release, "--namespace", r.Namespace)
-		}
+		t.Logf("Running 'tobs timescaledb connect %v'", user)
+		connect = exec.Command(PATH_TO_TOBS, "timescaledb", "connect", user, "-n", r.Release, "--namespace", r.Namespace)
+	}
+
+	err := connect.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * time.Second)
+	err = connect.Process.Signal(syscall.SIGINT)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (r *ReleaseInfo) TestTimescaleSuperUserConnect(t testing.TB, master bool) {
+	var connect *exec.Cmd
+
+	if master {
+		t.Logf("Running 'tobs timescaledb superuser connect -m'")
+		connect = exec.Command(PATH_TO_TOBS, "timescaledb", "superuser", "connect", "-m", "-n", r.Release, "--namespace", r.Namespace)
+	} else {
+		t.Logf("Running 'tobs timescaledb superuser connect'")
+		connect = exec.Command(PATH_TO_TOBS, "timescaledb", "superuser", "connect", "-n", r.Release, "--namespace", r.Namespace)
 	}
 
 	err := connect.Start()

--- a/cli/tests/tobs-cli-tests/metrics_test.go
+++ b/cli/tests/tobs-cli-tests/metrics_test.go
@@ -17,15 +17,8 @@ import (
 
 var PASS string
 
-func testRetentionSetDefault(t testing.TB, period int, user, dbname string) {
+func testRetentionSetDefault(t testing.TB, period int) {
 	cmds := []string{"metrics", "retention", "set-default", strconv.Itoa(period), "-n", RELEASE_NAME, "--namespace", NAMESPACE}
-	if user != "" {
-		cmds = append(cmds, "-U", user)
-	}
-	if dbname != "" {
-		cmds = append(cmds, "-d", dbname)
-	}
-
 	t.Logf("Running '%v'", "tobs "+strings.Join(cmds, " "))
 	set := exec.Command(PATH_TO_TOBS, cmds...)
 
@@ -36,15 +29,8 @@ func testRetentionSetDefault(t testing.TB, period int, user, dbname string) {
 	}
 }
 
-func testRetentionSet(t testing.TB, metric string, period int, user, dbname string) {
+func testRetentionSet(t testing.TB, metric string, period int) {
 	cmds := []string{"metrics", "retention", "set", metric, strconv.Itoa(period), "-n", RELEASE_NAME, "--namespace", NAMESPACE}
-	if user != "" {
-		cmds = append(cmds, "-U", user)
-	}
-	if dbname != "" {
-		cmds = append(cmds, "-d", dbname)
-	}
-
 	t.Logf("Running '%v'", "tobs "+strings.Join(cmds, " "))
 	set := exec.Command(PATH_TO_TOBS, cmds...)
 
@@ -55,15 +41,8 @@ func testRetentionSet(t testing.TB, metric string, period int, user, dbname stri
 	}
 }
 
-func testRetentionReset(t testing.TB, metric, user, dbname string) {
+func testRetentionReset(t testing.TB, metric string) {
 	cmds := []string{"metrics", "retention", "reset", metric, "-n", RELEASE_NAME, "--namespace", NAMESPACE}
-	if user != "" {
-		cmds = append(cmds, "-U", user)
-	}
-	if dbname != "" {
-		cmds = append(cmds, "-d", dbname)
-	}
-
 	t.Logf("Running '%v'", "tobs "+strings.Join(cmds, " "))
 	reset := exec.Command(PATH_TO_TOBS, cmds...)
 
@@ -74,15 +53,8 @@ func testRetentionReset(t testing.TB, metric, user, dbname string) {
 	}
 }
 
-func testRetentionGet(t testing.TB, metric string, expectedDays int64, user, dbname string) {
+func testRetentionGet(t testing.TB, metric string, expectedDays int64) {
 	cmds := []string{"metrics", "retention", "get", metric, "-n", RELEASE_NAME, "--namespace", NAMESPACE}
-	if user != "" {
-		cmds = append(cmds, "-U", user)
-	}
-	if dbname != "" {
-		cmds = append(cmds, "-d", dbname)
-	}
-
 	t.Logf("Running '%v'", "tobs "+strings.Join(cmds, " "))
 	get := exec.Command(PATH_TO_TOBS, cmds...)
 
@@ -102,15 +74,8 @@ func testRetentionGet(t testing.TB, metric string, expectedDays int64, user, dbn
 	}
 }
 
-func testChunkIntervalSetDefault(t testing.TB, interval, user, dbname string) {
+func testChunkIntervalSetDefault(t testing.TB, interval string) {
 	cmds := []string{"metrics", "chunk-interval", "set-default", interval, "-n", RELEASE_NAME, "--namespace", NAMESPACE}
-	if user != "" {
-		cmds = append(cmds, "-U", user)
-	}
-	if dbname != "" {
-		cmds = append(cmds, "-d", dbname)
-	}
-
 	t.Logf("Running '%v'", "tobs "+strings.Join(cmds, " "))
 	set := exec.Command(PATH_TO_TOBS, cmds...)
 
@@ -121,15 +86,8 @@ func testChunkIntervalSetDefault(t testing.TB, interval, user, dbname string) {
 	}
 }
 
-func testChunkIntervalSet(t testing.TB, metric, interval, user, dbname string) {
+func testChunkIntervalSet(t testing.TB, metric, interval string) {
 	cmds := []string{"metrics", "chunk-interval", "set", metric, interval, "-n", RELEASE_NAME, "--namespace", NAMESPACE}
-	if user != "" {
-		cmds = append(cmds, "-U", user)
-	}
-	if dbname != "" {
-		cmds = append(cmds, "-d", dbname)
-	}
-
 	t.Logf("Running '%v'", "tobs "+strings.Join(cmds, " "))
 	set := exec.Command(PATH_TO_TOBS, cmds...)
 
@@ -140,15 +98,8 @@ func testChunkIntervalSet(t testing.TB, metric, interval, user, dbname string) {
 	}
 }
 
-func testChunkIntervalReset(t testing.TB, metric, user, dbname string) {
+func testChunkIntervalReset(t testing.TB, metric string) {
 	cmds := []string{"metrics", "chunk-interval", "reset", metric, "-n", RELEASE_NAME, "--namespace", NAMESPACE}
-	if user != "" {
-		cmds = append(cmds, "-U", user)
-	}
-	if dbname != "" {
-		cmds = append(cmds, "-d", dbname)
-	}
-
 	t.Logf("Running '%v'", "tobs "+strings.Join(cmds, " "))
 	reset := exec.Command(PATH_TO_TOBS, cmds...)
 
@@ -159,15 +110,8 @@ func testChunkIntervalReset(t testing.TB, metric, user, dbname string) {
 	}
 }
 
-func testChunkIntervalGet(t testing.TB, metric string, expectedDuration time.Duration, user, dbname string) {
+func testChunkIntervalGet(t testing.TB, metric string, expectedDuration time.Duration) {
 	cmds := []string{"metrics", "chunk-interval", "get", metric, "-n", RELEASE_NAME, "--namespace", NAMESPACE}
-	if user != "" {
-		cmds = append(cmds, "-U", user)
-	}
-	if dbname != "" {
-		cmds = append(cmds, "-d", dbname)
-	}
-
 	t.Logf("Running '%v'", "tobs "+strings.Join(cmds, " "))
 	get := exec.Command(PATH_TO_TOBS, cmds...)
 
@@ -230,7 +174,7 @@ func verifyChunkInterval(t testing.TB, tableName string, expectedDuration time.D
 		t.Fatal(err)
 	}
 
-	dur := time.Duration(time.Duration(intervalLength) * time.Microsecond)
+	dur := time.Duration(intervalLength) * time.Microsecond
 	if dur.Round(time.Hour) != expectedDuration.Round(time.Hour) {
 		t.Errorf("Unexpected chunk interval for table %v: got %v want %v", tableName, dur, expectedDuration)
 	}
@@ -272,53 +216,52 @@ func TestMetrics(t *testing.T) {
 	}
 	os.Stdout = stdout
 
-	testRetentionSetDefault(t, 10, "", "")
+	testRetentionSetDefault(t, 10)
 	verifyRetentionPeriod(t, "container_last_seen", 10*24*time.Hour)
 
-	testRetentionReset(t, "up", "", "")
+	testRetentionReset(t, "up")
 	verifyRetentionPeriod(t, "up", 10*24*time.Hour)
 
-	testRetentionSet(t, "node_load15", 9, "", "postgres")
+	testRetentionSet(t, "node_load15", 9)
 	verifyRetentionPeriod(t, "node_load15", 9*24*time.Hour)
 
-	testRetentionSet(t, "up", 2, "postgres", "")
+	testRetentionSet(t, "up", 2)
 	verifyRetentionPeriod(t, "up", 2*24*time.Hour)
 
-	testRetentionSet(t, "kube_pod_status_phase", 32, "", "postgres")
+	testRetentionSet(t, "kube_pod_status_phase", 32)
 	verifyRetentionPeriod(t, "kube_pod_status_phase", 32*24*time.Hour)
 
-	testRetentionReset(t, "up", "", "")
+	testRetentionReset(t, "up")
 	verifyRetentionPeriod(t, "up", 10*24*time.Hour)
 
-	testRetentionReset(t, "node_load5", "", "")
+	testRetentionReset(t, "node_load5")
 	verifyRetentionPeriod(t, "node_load5", 10*24*time.Hour)
 
-	testRetentionSetDefault(t, 11, "", "postgres")
+	testRetentionSetDefault(t, 11)
 	verifyRetentionPeriod(t, "go_info", 11*24*time.Hour)
 
-	testRetentionGet(t, "node_load5", 11, "", "")
+	testRetentionGet(t, "node_load5", 11)
 
-	testChunkIntervalSet(t, "container_last_seen", "23m45s", "", "")
+	testChunkIntervalSet(t, "container_last_seen", "23m45s")
 	verifyChunkInterval(t, "container_last_seen", (23*60+45)*time.Second)
 
-	testChunkIntervalSetDefault(t, "62m3s", "", "")
+	testChunkIntervalSetDefault(t, "62m3s")
 	verifyChunkInterval(t, "node_load15", (62*60+3)*time.Second)
 
-	testChunkIntervalSet(t, "go_info", "3403s", "postgres", "postgres")
+	testChunkIntervalSet(t, "go_info", "3403s")
 	verifyChunkInterval(t, "go_info", 3403*time.Second)
 
-	testChunkIntervalGet(t, "node_load15", (62*60+3)*time.Second, "", "")
+	testChunkIntervalGet(t, "node_load15", (62*60+3)*time.Second)
 
-	testChunkIntervalReset(t, "go_info", "", "postgres")
+	testChunkIntervalReset(t, "go_info")
 	verifyChunkInterval(t, "go_info", (62*60+3)*time.Second)
 
-	testChunkIntervalSet(t, "kube_job_info", "8h24m", "", "")
+	testChunkIntervalSet(t, "kube_job_info", "8h24m")
 	verifyChunkInterval(t, "kube_job_info", (8*60+24)*time.Minute)
 
-	testChunkIntervalSetDefault(t, "23h", "", "postgres")
+	testChunkIntervalSetDefault(t, "23h")
 	verifyChunkInterval(t, "kube_pod_status_phase", (23)*time.Hour)
 
-	testChunkIntervalReset(t, "go_threads", "", "")
+	testChunkIntervalReset(t, "go_threads")
 	verifyChunkInterval(t, "go_threads", (23)*time.Hour)
-
 }

--- a/cli/tests/tobs-cli-tests/timescale_superuser_test.go
+++ b/cli/tests/tobs-cli-tests/timescale_superuser_test.go
@@ -1,17 +1,16 @@
-package external_db_tests
+package tobs_cli_tests
 
 import (
-	"fmt"
-	test_utils "github.com/timescale/tobs/cli/tests/test-utils"
 	"testing"
+
+	test_utils "github.com/timescale/tobs/cli/tests/test-utils"
 )
 
-func TestTimescale(t *testing.T) {
+func TestTimescaleSuper(t *testing.T) {
 	if testing.Short() {
-		t.Skip("Skipping TimescaleDB tests")
+		t.Skip("Skipping TimescaleDB Super User tests")
 	}
 
-	fmt.Println("Performing TimescaleDB tests for external db setup...")
 	releaseInfo := test_utils.ReleaseInfo{
 		Release:   RELEASE_NAME,
 		Namespace: NAMESPACE,
@@ -20,12 +19,13 @@ func TestTimescale(t *testing.T) {
 	releaseInfo.TestTimescaleGetPassword(t)
 	releaseInfo.TestTimescaleChangePassword(t, "battery")
 	releaseInfo.VerifyTimescalePassword(t, "battery")
-
 	releaseInfo.TestTimescaleGetPassword(t)
 	releaseInfo.TestTimescaleChangePassword(t, "chips")
 	releaseInfo.VerifyTimescalePassword(t, "chips")
 
 	releaseInfo.TestTimescaleSuperUserConnect(t, true)
+	releaseInfo.TestTimescaleSuperUserConnect(t, false)
+	releaseInfo.TestTimescaleSuperUserConnect(t, false)
 	releaseInfo.TestTimescaleSuperUserConnect(t, false)
 	releaseInfo.TestTimescaleSuperUserConnect(t, false)
 	releaseInfo.TestTimescaleSuperUserConnect(t, false)

--- a/cli/tests/tobs-cli-tests/timescale_test.go
+++ b/cli/tests/tobs-cli-tests/timescale_test.go
@@ -15,13 +15,6 @@ func TestTimescale(t *testing.T) {
 		Namespace: NAMESPACE,
 	}
 
-	releaseInfo.TestTimescaleGetPassword(t, "")
-	releaseInfo.TestTimescaleChangePassword(t, "", "postgres", "battery")
-	releaseInfo.VerifyTimescalePassword(t, "postgres", "battery")
-	releaseInfo.TestTimescaleGetPassword(t, "")
-	releaseInfo.TestTimescaleChangePassword(t, "", "", "chips")
-	releaseInfo.VerifyTimescalePassword(t, "", "chips")
-
 	releaseInfo.TestTimescalePortForward(t, "")
 	releaseInfo.TestTimescalePortForward(t, "5432")
 	releaseInfo.TestTimescalePortForward(t, "1789")


### PR DESCRIPTION
Refactor `tobs timescaledb` command

Currently `tobs timescaledb` cmds i.e. `get-password`, `change-password`, `connect` use by default superuser creds. So to let users know that we are changing these cmds to 
```
tobs timescaledb superuser connect
tobs timescaledb superuser get-password
tobs timescaledb superuser change-password
```

However if the user wants to connect to DB with their own user creds they can use below cmd. In this option you can also configure `dbname`

```
tobs timescaledb connect <user> --dbname <db-name> 
```

**tobs timescaledb**

```
$ ./bin/tobs timescaledb          
Subcommand for TimescaleDB operations

Usage:
  tobs timescaledb [command]

Available Commands:
  connect      Connects to the TimescaleDB database
  port-forward Port-forwards TimescaleDB server to localhost
  superuser    Subcommand for TimescaleDB super-user operations

Flags:
  -h, --help   help for timescaledb

Global Flags:
  -n, --name string        Helm release name (default "tobs")
      --namespace string   Kubernetes namespace (default "default")
```

**tobs timescaledb superuser**

```
$ ./bin/tobs timescaledb superuser
Subcommand for TimescaleDB super-user operations

Usage:
  tobs timescaledb superuser [command]

Available Commands:
  change-password Changes the TimescaleDB super-user password
  connect         Connects to the TimescaleDB database
  get-password    Gets the TimescaleDB password for a specific user

Flags:
  -h, --help   help for superuser

Global Flags:
  -n, --name string        Helm release name (default "tobs")
      --namespace string   Kubernetes namespace (default "default")
```
**Note:** With `tobs timescaledb superuser` cmd there are no `--dbname` and `--user` flags. I dropped them. As we now can fetch the DB details configured by the user from helm values. 

**tobs metrics**
 
We dropped `--user` and `--dbname` flags from `tobs metrics` cmd. Because previously tobs didn't have an ability to read `dbuser` and `dbname`  from the helm values file. But now we fetch the db details from the helm values file. So this is covered by default. I do not see a use case where a user wants to specify a custom dbname or dbuser to view or update `chunk-interval` and `retention`.   