### PR TITLE
Minor bug fixes

### DIFF
--- a/chart/templates/grafana-datasources-sec.yaml
+++ b/chart/templates/grafana-datasources-sec.yaml
@@ -23,7 +23,7 @@ stringData:
 
     datasources:
 {{- if $promEnabled }}
-      - name: Prometheus
+      - name: Promscale
         type: prometheus
         url: {{ tpl $grafana.prometheus.datasource.url . }}
         isDefault: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -84,6 +84,8 @@ kube-prometheus-stack:
       scrapeInterval: "1m"
       scrapeTimeout: "10s"
       evaluationInterval: "1m"
+      ## Prometheus metric retention
+      retention: 1d
       ## The remote_read spec configuration for Prometheus.
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotereadspec
       remoteRead:

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -290,7 +290,7 @@ func (c *InstallSpec) createSecrets() error {
 	// equal to or greater than 0.3.0
 	// if version isn't provided new
 	// installations needs secrets
-	if i > 3000 || c.version == "" {
+	if i >= 3000 || c.version == "" {
 		t := timescaledb_secrets.TSDBSecretsInfo{
 			ReleaseName:    cmd.HelmReleaseName,
 			Namespace:      cmd.Namespace,

--- a/cli/cmd/uninstall/uninstall.go
+++ b/cli/cmd/uninstall/uninstall.go
@@ -118,7 +118,7 @@ func helmUninstall(cmd *cobra.Command, args []string) error {
 }
 
 func delete040UpgradeJob(helmClient helm.Client, k8sClient k8s.Client) error {
-	deployedChart, err := helmClient.GetDeployedChartMetadata(root.HelmReleaseName)
+	deployedChart, err := helmClient.GetDeployedChartMetadata(root.HelmReleaseName, root.Namespace)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -105,7 +105,7 @@ func upgradeTobs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	deployedChart, err := helmClient.GetDeployedChartMetadata(root.HelmReleaseName)
+	deployedChart, err := helmClient.GetDeployedChartMetadata(root.HelmReleaseName, root.Namespace)
 	if err != nil {
 		if err.Error() != utils.ErrorTobsDeploymentNotFound(root.HelmReleaseName).Error() {
 			return err
@@ -232,7 +232,10 @@ func (c *upgradeSpec) UpgradePathBasedOnVersion() error {
 		return fmt.Errorf("failed to parse 0.2.2 version %w", err)
 	}
 
-	if nVersion >= version0_4_0 {
+	// kube-prometheus is introduced on tobs >= 0.4.0 release
+	// so create CRDs if version >= 0.4.0 and only create CRDs
+	// if version change is noticed in upgrades...
+	if nVersion >= version0_4_0 && nVersion != dVersion {
 		if !c.skipCrds {
 			err = createCRDS()
 			if err != nil {

--- a/cli/cmd/version/version.go
+++ b/cli/cmd/version/version.go
@@ -34,7 +34,7 @@ func version(cmd *cobra.Command, args []string) error {
 	helmClient := helm.NewClient(root.Namespace)
 	defer helmClient.Close()
 	if d {
-		deployedChart, err := helmClient.GetDeployedChartMetadata(root.HelmReleaseName)
+		deployedChart, err := helmClient.GetDeployedChartMetadata(root.HelmReleaseName, root.Namespace)
 		if err != nil {
 			chartVersion = fmt.Errorf("failed to get the deployed chart version: %v", err).Error()
 		} else {

--- a/cli/pkg/helm/client.go
+++ b/cli/pkg/helm/client.go
@@ -13,7 +13,7 @@ type Client interface {
 	GetReleaseValues(name string) (map[string]interface{}, error)
 	GetChartValues(name string) ([]byte, error)
 	UninstallRelease(spec *ChartSpec) error
-	GetDeployedChartMetadata(releaseName string) (*DeployedChartMetadata, error)
+	GetDeployedChartMetadata(releaseName, namespace string) (*DeployedChartMetadata, error)
 	ExportValuesFieldFromRelease(releaseName string, keys []string) (interface{}, error)
 	ExportValuesFieldFromChart(chart string, customValuesFile string, keys []string) (interface{}, error)
 	GetChartMetadata(chart string) (*ChartMetadata, error)

--- a/cli/pkg/helm/client_impl.go
+++ b/cli/pkg/helm/client_impl.go
@@ -160,9 +160,9 @@ func (c *clientImpl) GetChartMetadata(chart string) (*ChartMetadata, error) {
 	return nil, fmt.Errorf("failed to get Chart.yaml from the provided chart")
 }
 
-func (c *clientImpl) GetDeployedChartMetadata(releaseName string) (*DeployedChartMetadata, error) {
+func (c *clientImpl) GetDeployedChartMetadata(releaseName, namespace string) (*DeployedChartMetadata, error) {
 	var charts []DeployedChartMetadata
-	l, err := c.listDeployedReleases()
+	l, err := c.listDeployedReleases(namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -581,12 +581,12 @@ func setUninstallReleaseOptions(chartSpec *ChartSpec, uninstallReleaseOptions *a
 
 // ListDeployedReleases lists all deployed releases.
 // Namespace and other context is provided via the Options struct when instantiating a client.
-func (c *clientImpl) listDeployedReleases() ([]*release.Release, error) {
-	err := c.actionConfig.Init(c.settings.RESTClientGetter(), "", "", func(_ string, _ ...interface{}) {})
+func (c *clientImpl) listDeployedReleases(namespace string) ([]*release.Release, error) {
+	err := c.actionConfig.Init(c.settings.RESTClientGetter(), namespace, "", func(_ string, _ ...interface{}) {})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list deployed releases %v", err)
 	}
 	listClient := action.NewList(c.actionConfig)
-	listClient.StateMask = action.ListDeployed
+	listClient.StateMask = action.ListDeployed | action.ListFailed | action.ListPendingInstall | action.ListPendingUpgrade
 	return listClient.Run()
 }

--- a/cli/tests/ha-tests/ha_test.go
+++ b/cli/tests/ha-tests/ha_test.go
@@ -44,7 +44,7 @@ func TestHASetup(t *testing.T) {
 		for i < 5 {
 			_ = test_utils.DeletePod(oldLeader, NAMESPACE)
 			i++
-			time.Sleep(3 * time.Second)
+			time.Sleep(5 * time.Second)
 		}
 		// Prometheus new leader after
 		// shutting down the old Prometheus leader
@@ -55,9 +55,9 @@ func TestHASetup(t *testing.T) {
 			break
 		}
 
-		// Every retry consumes 3 secs sleep * 5 attempts = 15 secs
+		// Every retry consumes 5 secs sleep * 5 attempts = 25 secs
 		// In Promscale Prometheus leader change over happens when
-		// the last write request is older than 30s. Approx after 3 retries i.e. 45 secs
+		// the last write request is older than 30s. Approx after 3 retries i.e. 1m 15s secs
 		// the change-over should happen :)
 		if retries == 10 {
 			t.Fatal("Leader switch over doesn't happen after multiple retries....")

--- a/cli/tests/helm-tests/helm_test.go
+++ b/cli/tests/helm-tests/helm_test.go
@@ -108,7 +108,7 @@ func testHelmClientInstallOrUpgradeChart() {
 
 // list tobs deployment and verify it post uninstall
 func testTobsReleasePostUninstall() {
-	res, err := helmClientTest.GetDeployedChartMetadata("tobs")
+	res, err := helmClientTest.GetDeployedChartMetadata("tobs", NAMESPACE)
 	if err == nil && res.Name == DEFAULT_TOBS_NAME {
 		log.Fatal("the tobs release after uninstalling are still showing up....", res)
 	}
@@ -168,7 +168,7 @@ func TestGetChartValues(t *testing.T) {
 }
 
 func TestGetDeployedChartMetadata(t *testing.T) {
-	chart, err := helmClientTest.GetDeployedChartMetadata(DEFAULT_TOBS_NAME)
+	chart, err := helmClientTest.GetDeployedChartMetadata(DEFAULT_TOBS_NAME, NAMESPACE)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/tests/upgrade-tests/upgrade_test.go
+++ b/cli/tests/upgrade-tests/upgrade_test.go
@@ -94,7 +94,7 @@ func TestUpgrade(t *testing.T) {
 
 	helmClient = helm.NewClient(NAMESPACE)
 	defer helmClient.Close()
-	chartDetails, err := helmClient.GetDeployedChartMetadata(RELEASE_NAME)
+	chartDetails, err := helmClient.GetDeployedChartMetadata(RELEASE_NAME, NAMESPACE)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
1. Add default Prometheus instance retention to `1d`. 
2. Change Promscale datasource name from Prometheus to Promscale. This will be used to display the name in Grafana UI. 
3. Tobs install should create secrets for versions >= `0.3.0`. Added the = which was missed. This is a bug only if a user installs the tobs by explicitly providing the version as `0.3.0`. **Note**: Installation based on version wasn't available in version 0.3.0. So this just makes the validation better. 
4. If the Kubernetes cluster is big with 10's of helm releases finding the existing tobs installation was failing as the helm client was timed out. So now to find the existing tobs helm release we will search in a specific namespace which makes finding the release much easier. 
5. For some reason if an upgrade is failed or went into a pending state. Tobs CLI couldn't find the release as it isn't in the deployed state. This makes debugging a failed upgrade tougher and CLI can't help in such cases. So from now tobs CLI will list the failed and pending releases to retry the upgrades or find the current state of a release. 
6. On upgrade attempt to apply CRDs creation only if we notice version change between deployed version vs new version. Currently, CRDs creation message misleading on upgrading to the same version with changes in `values.yaml`.  
7. In daily run tests HA tests we are experiencing flakiness, so increasing the retry mechanism sleep overtime to 5 seconds from 3 seconds. This gives a decent amount of time for Promscale HA leader transfer to happen. 