### PR TITLE
On tracing enabled support uninstall

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -403,13 +403,10 @@ promlens:
 opentelemetryOperator:
   enabled: false
   jaegerPromscaleQuery:
-    # later will be chnaged to Jaeger query that includes Promscale plugin
-    image: vineeth97/promscale-jaeger-query
+    image: timescale/jaeger-query-proxy:0.0.1
     endpoint: "{{ .Release.Name }}-jaeger-promscale.{{ .Release.Namespace }}.svc.cluster.local:16686"
     args:
       - --grpc-storage-plugin.configuration-file=/configs/jaeger-promscale-query.yaml
-      - --grpc-storage-plugin.binary=/tmp/promscale-jaeger-plugin
-      - --query.max-clock-skew-adjustment=1s
     config: |
       promscale-tls: false
       promscale-grpc-server: "{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9202"

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -236,7 +236,7 @@ timescaledb-single:
 		var ok bool
 		c.enableOtel, ok = e.(bool)
 		if !ok {
-			return fmt.Errorf("enable otel was not a bool")
+			return fmt.Errorf("opentelemetryOperator.enabled is not a bool")
 		}
 	}
 
@@ -292,7 +292,13 @@ timescaledb-single:
 
 	// create the default otelcol CR as operator should be is up & running by now....
 	if c.enableOtel {
-		err = otel.CreateDefaultCollector(cmd.HelmReleaseName, cmd.Namespace, c.otelColConfig)
+		otelCol := otel.OtelCol{
+			ReleaseName: cmd.HelmReleaseName,
+			Namespace:   cmd.Namespace,
+			K8sClient:   k8sClient,
+			HelmClient:  helmClient,
+		}
+		err = otelCol.CreateDefaultCollector(c.otelColConfig)
 		if err != nil {
 			return err
 		}
@@ -332,6 +338,7 @@ func appendPromscaleValues(enableOtel, promHA bool, dbURI string) string {
 promscale:`
 	if enableOtel {
 		config = config + `
+  image: timescale/promscale:0.7.0-beta.latest
   tracing:
     enabled: true`
 

--- a/cli/pkg/k8s/client.go
+++ b/cli/pkg/k8s/client.go
@@ -60,7 +60,10 @@ type Client interface {
 
 	// namespace specific actions
 	CreateNamespaceIfNotExists(namespace string) error
+	UpdateNamespaceLabels(name string, labels map[string]string) error
+	GetNamespaceLabels(name string) (map[string]string, error)
 
-	// create CR
+	// CR operations
 	CreateCustomResource(namespace, apiVersion, resourceName string, body []byte) error
+	DeleteCustomResource(namespace, apiVersion, resourceName, crName string) error
 }


### PR DESCRIPTION
1. If `cert-manager` is installed by tobs log a WARNING that user needs to manually delete it. As other resources in the cluster might be dependent on it.
2. On uninstall while tracing is enabled delete manually the default collector created + otelcol CRD (as this isn't handled by helm uninstall) 
3. On tracing enabled, override the default image to Promscale `0.7.0-beta.latest`