### PR TITLE
Fix disable TimescaleDB issue 

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -7,7 +7,7 @@
 {{- end }}
 {{- if index .Values "timescaledb-single" "enabled" }}
 🐯 TimescaleDB
-{{- else }}
+{{- else if index .Values "timescaledbExternal" "enabled" }}
 🐯 Connecting to an External TimescaleDB
 {{- end }}
 {{- if index .Values "promscale" "enabled" }}
@@ -103,7 +103,8 @@ WARNING! Persistence is disabled on AlertManager.
 {{- end }}
 
 {{- end }}
-{{- if or .Values "timescaledb-single" "enabled" .Values.timescaledbExternal.enabled }}
+
+{{- if or (index .Values "timescaledb-single" "enabled") (index .Values "timescaledbExternal" "enabled") }}
 {{- $tsEnv := (set (set (deepCopy .) "Values" (index .Values "timescaledb-single")) "Chart" (dict "Name" "timescaledb")) }}
 
 ###############################################################################
@@ -274,5 +275,4 @@ WARNING! Persistence is disabled!!! You will lose your data when
 {{- end }}
 
 🚀 Happy observing!
-
 


### PR DESCRIPTION
Currently, If TimescaleDB is disabled. The installation can work in two modes
1. Connecting to an external TimescaleDB
2. Deploying an observer cluster i.e. only Prometheus components will be deployed (this setup acts as an observer cluster) will write the data to a centralized Promscale instance outside the cluster. 

Issues fixed:
1. If TimescaleDB isn't deployed. We by default consider that we are connecting to an external database. But there is another case where the tobs is deployed as the observer cluster. In this case, we do not need any DB secrets to be created + the rendering of `NOTES.txt` needs to be fixed.

Fixes: #181  