### PR TITLE
Upgrade path for 0.8.0

### DIFF
--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -396,7 +396,7 @@ promscale:`
 		config = config + `
   replicaCount: 3`
 		args = args + `
-  - --high-availability`
+  - --metrics.high-availability`
 	}
 
 	if dbURI != "" {

--- a/cli/cmd/uninstall/uninstall.go
+++ b/cli/cmd/uninstall/uninstall.go
@@ -96,13 +96,17 @@ func helmUninstall(cmd *cobra.Command, args []string) error {
 			fmt.Printf("ERROR: couldn't find the cert-manager status %v", err)
 		}
 		if certManagerInstalled {
+			cmVersion, err := otelCol.GetCertManagerVersion()
+			if err != nil {
+				return err
+			}
 			fmt.Printf(`
 WARNING: Cert-manager, version: %s  is installed by tobs, 
 As cert-manager can be used by other components running in the cluster.
 We are leaving the task of uninstalling cert-manager to the user.
 Steps to uninstall cert-manager is documented here: https://cert-manager.io/docs/installation/kubectl/#uninstalling
 
-`, otel.CertManagerVersion)
+`, cmVersion)
 		}
 	}
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -5,12 +5,15 @@ go 1.17
 require (
 	github.com/jackc/pgconn v1.10.0
 	github.com/jackc/pgx/v4 v4.13.0
+	github.com/jetstack/cert-manager v1.6.1
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/open-telemetry/opentelemetry-operator v0.35.0
 	github.com/pkg/errors v0.9.1
 	github.com/sergi/go-diff v1.2.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.9.0
+	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.7.0
 	k8s.io/api v0.22.2
 	k8s.io/apiextensions-apiserver v0.22.2
@@ -121,6 +124,7 @@ require (
 	github.com/prometheus/common v0.31.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rodaine/table v1.0.1 // indirect
 	github.com/rubenv/sql-migrate v0.0.0-20210614095031-55d5740dbbcc // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
@@ -136,8 +140,8 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
 	go.starlark.net v0.0.0-20210901212718-87f333178d59 // indirect
-	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
-	golang.org/x/net v0.0.0-20210610132358-84b48f89b13b // indirect
+	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
+	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
@@ -146,13 +150,12 @@ require (
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20211001223012-bfb93cce50d9 // indirect
+	google.golang.org/genproto v0.0.0-20211005153810-c76a74d43a8e // indirect
 	google.golang.org/grpc v1.41.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/gorp.v1 v1.7.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.63.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiserver v0.22.2 // indirect
 	k8s.io/component-base v0.22.2 // indirect
@@ -161,7 +164,7 @@ require (
 	k8s.io/kubectl v0.22.2 // indirect
 	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b // indirect
 	oras.land/oras-go v0.4.0 // indirect
-	sigs.k8s.io/controller-runtime v0.9.6 // indirect
+	sigs.k8s.io/controller-runtime v0.10.1 // indirect
 	sigs.k8s.io/kustomize/api v0.10.0 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.12.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -958,6 +958,8 @@ github.com/jackc/puddle v1.1.4 h1:5Ey/o5IfV7dYX6Znivq+N9MdK1S18OJI5OJq6EAAADw=
 github.com/jackc/puddle v1.1.4/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jetstack/cert-manager v1.6.1 h1:VME4bVID2gVTfebO5X4Nq9FvKvvi3+VLcA0mmtYlKuw=
+github.com/jetstack/cert-manager v1.6.1/go.mod h1:1nXjnzzsYcIFvl4eLTkVqpvh9NQogkCq4FaCmgvNDDY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -1186,6 +1188,7 @@ github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DV
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -1207,6 +1210,7 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.14.0 h1:ep6kpPVwmr/nTbklSx2nrLNSIO62DoYAhnPNIMhK8gI=
 github.com/onsi/gomega v1.14.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
+github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/open-telemetry/opentelemetry-operator v0.35.0 h1:u7mH9Px4GWOfjm6iU5g4xl1Tj8g/CVDJWHNiU6DL27E=
 github.com/open-telemetry/opentelemetry-operator v0.35.0/go.mod h1:UtPjKhGWuzu4SImpluIs3jeO7TJuCr7teibGc+3mqGE=
@@ -1345,6 +1349,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/retailnext/hllpp v1.0.1-0.20180308014038-101a6d2f8b52/go.mod h1:RDpi1RftBQPUCDRw6SmxeaREsAaRKnOclghuzp/WRzc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rodaine/table v1.0.1 h1:U/VwCnUxlVYxw8+NJiLIuCxA/xa6jL38MY3FYysVWWQ=
+github.com/rodaine/table v1.0.1/go.mod h1:UVEtfBsflpeEcD56nF4F5AocNFta0ZuolpSVdPtlmP4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -1596,6 +1602,7 @@ go.uber.org/zap v1.14.1/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.18.1 h1:CSUJ2mjFszzEWt4CdKISEuChVIXGBn3lAPwkRGyVrc4=
 go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
+go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180505025534-4ec37c66abab/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -1638,6 +1645,8 @@ golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
+golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1746,6 +1755,8 @@ golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b h1:k+E048sYJHyVnsr1GDrRZWQ32D2C7lWs9JRc0bel53A=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d h1:20cMwl2fHAzkJMEA+8J4JgqBQcQGzbisXo31MIeenXI=
+golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1891,6 +1902,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 h1:foEbQz/B0Oz6YIqu/69kfXPYeFQAuuMYFkjaqXzl5Wo=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -2124,6 +2136,8 @@ google.golang.org/genproto v0.0.0-20210821163610-241b8fcbd6c8/go.mod h1:eFjDcFEc
 google.golang.org/genproto v0.0.0-20210828152312-66f60bf46e71/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
 google.golang.org/genproto v0.0.0-20211001223012-bfb93cce50d9 h1:eF1wcrhdz56Vugf8qNX5dD93ItkrhothojQyHXqloe0=
 google.golang.org/genproto v0.0.0-20211001223012-bfb93cce50d9/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20211005153810-c76a74d43a8e h1:Im71rbA1N3CbIag/PumYhQcNR8bLNmuOtRIyOnnLsT8=
+google.golang.org/genproto v0.0.0-20211005153810-c76a74d43a8e/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -2344,6 +2358,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.19/go.mod h1:LEScyz
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/controller-runtime v0.9.6 h1:EevVMlgUj4fC1NVM4+DB3iPkWkmGRNarA66neqv9Qew=
 sigs.k8s.io/controller-runtime v0.9.6/go.mod h1:q6PpkM5vqQubEKUKOM6qr06oXGzOBcCby1DA9FbyZeA=
+sigs.k8s.io/controller-runtime v0.10.1 h1:+eLHgY/VrJWnfg6iXUqhCUqNXgPH1NZeP9drNAAgWlg=
+sigs.k8s.io/controller-runtime v0.10.1/go.mod h1:CQp8eyUQZ/Q7PJvnIrB6/hgfTC1kBkGylwsLgOQi1WY=
 sigs.k8s.io/kustomize/api v0.8.11/go.mod h1:a77Ls36JdfCWojpUqR6m60pdGY1AYFix4AH83nJtY1g=
 sigs.k8s.io/kustomize/api v0.10.0 h1:HK5gVSlVV24AmZ2fTHUIchZ6osaYNegK1jAdx7lJ/mU=
 sigs.k8s.io/kustomize/api v0.10.0/go.mod h1:syysqD8Oews9oghLfCitMCuCPxxu4MErSJ6uw8ge9jk=

--- a/cli/pkg/k8s/client.go
+++ b/cli/pkg/k8s/client.go
@@ -22,6 +22,7 @@ type Client interface {
 	// deployment specific actions
 	GetDeployment(name, namespace string) (*appsv1.Deployment, error)
 	UpdateDeployment(deployment *appsv1.Deployment) error
+	DeleteDeployment(labels map[string]string, namespace string) error
 
 	// service specific actions
 	KubeGetServiceName(namespace string, labelmap map[string]string) (string, error)
@@ -67,6 +68,9 @@ type Client interface {
 	CreateCustomResource(namespace, apiVersion, resourceName string, body []byte) error
 	DeleteCustomResource(namespace, apiVersion, resourceName, crName string) error
 
+	// List cert-manager Certificate resources
+	ListCertManagerDeprecatedCRs() ([]ResourceDetails, error)
+
 	// Apply manifests
-	ApplyManifests(data []byte) error
+	ApplyManifests(map[string]string) error
 }

--- a/cli/pkg/otel/otel-utilities.go
+++ b/cli/pkg/otel/otel-utilities.go
@@ -3,10 +3,10 @@ package otel
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
+	"os"
 	"strings"
 
+	"github.com/olekukonko/tablewriter"
 	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
 	"github.com/timescale/tobs/cli/pkg/helm"
 	"github.com/timescale/tobs/cli/pkg/k8s"
@@ -25,8 +25,18 @@ const (
 )
 
 var (
-	CertManagerManifests = fmt.Sprintf("https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml", CertManagerVersion)
-	otelColCRD           = fmt.Sprintf("%s.opentelemetry.io", otelColResourceName)
+	certManagerManifests = map[string]string{
+		"cert-manager": fmt.Sprintf("https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml", CertManagerVersion),
+	}
+
+	otelColCRD = fmt.Sprintf("%s.opentelemetry.io", otelColResourceName)
+
+	openTelemetryCRDVersion     = "v0.41.1"
+	openTelemetryCRDsPathPrefix = fmt.Sprintf("https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/%s/bundle/manifests/", openTelemetryCRDVersion)
+	OpenTelemetryCRDs           = map[string]string{
+		"instrumentations.opentelemetry.io":        openTelemetryCRDsPathPrefix + "opentelemetry.io_instrumentations.yaml",
+		"opentelemetrycollectors.opentelemetry.io": openTelemetryCRDsPathPrefix + "opentelemetry.io_opentelemetrycollectors.yaml",
+	}
 )
 
 type OtelCol struct {
@@ -34,11 +44,12 @@ type OtelCol struct {
 	Namespace   string
 	K8sClient   k8s.Client
 	HelmClient  helm.Client
+	UpgradeCM   bool
 }
 
 func CreateCertManager(confirmActions bool) error {
 	apiClient := k8s.NewAPIClient()
-	_, err := apiClient.GetCRD("certificates.cert-manager.io")
+	crd, err := apiClient.GetCRD("certificates.cert-manager.io")
 	if err != nil {
 		if errors2.IsNotFound(err) {
 			fmt.Println("Couldn't find the cert-manager. The cert-manager is required to deploy OpenTelemetry. Do you want to install the cert-manager?")
@@ -46,51 +57,161 @@ func CreateCertManager(confirmActions bool) error {
 				utils.ConfirmAction()
 			}
 
-			res, err := http.Get(CertManagerManifests)
+			err = createUpgradeCertManager()
 			if err != nil {
-				return fmt.Errorf("failed to download %v", err)
-			}
-			defer res.Body.Close()
-
-			// Check server response
-			if res.StatusCode != http.StatusOK {
-				return fmt.Errorf("bad status: %s", res.Status)
-			}
-
-			// Writer the body to file
-			var out []byte
-			out, err = ioutil.ReadAll(res.Body)
-			if err != nil  {
-				return err
-			}
-
-			k8sClient := k8s.NewClient()
-			err = k8sClient.ApplyManifests(out)
-			if err != nil {
-				return fmt.Errorf("failed to apply cert-manager %v", err)
-			}
-
-			// verify cert-manager is up & running
-			pods, err := k8sClient.KubeGetPods(CertManagerNamespace, map[string]string{"app.kubernetes.io/instance": "cert-manager"})
-			if err != nil {
-				return err
-			}
-
-			for _, pod := range pods {
-				if err = k8sClient.KubeWaitOnPod(CertManagerNamespace, pod.Name); err != nil {
-					return err
-				}
-			}
-
-			if err = k8sClient.UpdateNamespaceLabels(CertManagerNamespace, map[string]string{"app.kubernetes.io/created-by": "tobs-cli"}); err != nil {
-				return err
+				return fmt.Errorf("failed to create cert-manager %v", err)
 			}
 			fmt.Println("Successfully created cert-manager")
 			return nil
 		}
 	}
-	fmt.Println("cert-manager exists in the cluster, skipping the installation...")
+
+	// validate the version of cer-manager in cluster
+	certManagerVersion := crd.Labels["app.kubernetes.io/version"]
+	ok, err := isDesiredVersion(certManagerVersion, CertManagerVersion)
+	if err != nil {
+		return err
+	}
+
+	if !ok {
+		return fmt.Errorf("existing cert-manager in the cluster with version %s doesn't comply with the"+
+			" OpenTelemetry Operator, requires cert-manager version %s", certManagerVersion, CertManagerVersion)
+	}
+
+	fmt.Printf("cert-manager version %s exists in the cluster, skipping the installation...\n", certManagerVersion)
 	return err
+}
+
+// this func check whether the current version >= desired version
+func isDesiredVersion(current, desired string) (bool, error) {
+	cV, err := utils.ParseVersion(strings.Replace(current, "v", "", 1), 3)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse %s version %w", current, err)
+	}
+
+	dV, err := utils.ParseVersion(strings.Replace(desired, "v", "", 1), 3)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse %s version %w", desired, err)
+	}
+
+	if cV < dV {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (c *OtelCol) ValidateCertManager() error {
+	certMInstalled, err := c.IsCertManagerInstalledByTobs()
+	if err != nil {
+		return fmt.Errorf("ERROR: couldn't find the cert-manager status %v", err)
+	}
+
+	cmVersion, err := c.GetCertManagerVersion()
+	if err != nil {
+		return err
+	}
+	ok, err := isDesiredVersion(cmVersion, CertManagerVersion)
+	if err != nil {
+		return err
+	}
+
+	// cert-manager is not installed by tobs
+	// ask user to upgrade their cert-manager isn't upto
+	// the version we expect...
+	if !certMInstalled {
+		fmt.Println("Cert-manager isn't installed or managed by tobs.")
+		if !ok {
+			return fmt.Errorf("existing cert-manager in the cluster with version %s doesn't comply with the"+
+				" OpenTelemetry Operator, requires cert-manager version %s", cmVersion, CertManagerVersion)
+		}
+	} else if !ok {
+		// cert-manager is installed by tobs, upgrade cert-manager,
+		// if others apps are using resources created by cert-manager
+		// notify users that XYZ are the resources managed by existing
+		// cert-manager, and error out stating these resources need a manual
+		// upgrade before completing the upgrade
+
+		certManagerResources, err := c.K8sClient.ListCertManagerDeprecatedCRs()
+		if err != nil {
+			return fmt.Errorf("failed to list certificate custom resources %v", err)
+		}
+
+		var onlyCertMResources []k8s.ResourceDetails
+		for _, resource := range certManagerResources {
+			// the listCMDeprecated resources gets them from otel-operator
+			// namespace this needs to be ignored as otel-operator helm-chart upgrades them
+			// Mote: Resource with name 'opentelemetry-operator-selfsigned-issuer` isn't part of
+			// any namespace so adding a check.
+			if resource.Namespace != "opentelemetry-operator-system"  {
+				if resource.Name != "opentelemetry-operator-selfsigned-issuer" {
+					onlyCertMResources = append(onlyCertMResources, resource)
+				}
+			}
+		}
+
+		if len(onlyCertMResources) > 0 {
+			fmt.Printf("\n!!! TOBS UPGRADE NEEDS MANUAL UPGRADE OF CERT-MANAGER RESOURCES: \n\n")
+
+			fmt.Printf("As tracing is enabled in tobs, upgrading tobs requires upgrading cert-manager to %s, "+
+				"The below listed cert-manager certificate resources are not managed by tobs and needs to be manually upgraded "+
+				"using: the cmctl utility or by using the kubectl cert-manager plugin to convert old manifests to v1.\n"+
+				"Follow this link for more details: https://cert-manager.io/docs/installation/upgrading/upgrading-1.5-1.6/ \n\n", CertManagerVersion)
+
+			table := tablewriter.NewWriter(os.Stdout)
+			table.SetHeader([]string{"Name", "Namespace", "APIVersion", "Resource Type"})
+
+			for _, v := range onlyCertMResources {
+				table.Append([]string{v.Name, v.Namespace, v.APIVersion, v.ResourceType})
+			}
+			table.Render()
+
+			fmt.Println()
+			return fmt.Errorf("cert-manager resources not owned by tobs needs manual upgrade")
+		}
+
+		fmt.Printf("Upgrading the cert-manager to %s\n", CertManagerVersion)
+		utils.ConfirmAction()
+		c.UpgradeCM = true
+	}
+
+	return nil
+}
+
+func UpgradeCertManager() error {
+	err := createUpgradeCertManager()
+	if err != nil {
+		return fmt.Errorf("failed to upgrade cert-manager %v", err)
+	}
+
+	fmt.Printf("Successfully upgraded cert-manager to %s\n", CertManagerVersion)
+	return err
+}
+
+func createUpgradeCertManager() error {
+	k8sClient := k8s.NewClient()
+	err := k8sClient.ApplyManifests(certManagerManifests)
+	if err != nil {
+		return fmt.Errorf("failed to apply cert-manager %v", err)
+	}
+
+	// verify cert-manager is up & running
+	pods, err := k8sClient.KubeGetPods(CertManagerNamespace, map[string]string{"app.kubernetes.io/instance": "cert-manager",
+		"app.kubernetes.io/version": CertManagerVersion})
+	if err != nil {
+		return err
+	}
+
+	for _, pod := range pods {
+		if err = k8sClient.KubeWaitOnPod(CertManagerNamespace, pod.Name); err != nil {
+			return err
+		}
+	}
+
+	if err = k8sClient.UpdateNamespaceLabels(CertManagerNamespace, map[string]string{"app.kubernetes.io/created-by": "tobs-cli"}); err != nil {
+		return err
+	}
+	return nil
 }
 
 func DeleteOtelColCRD() error {
@@ -114,6 +235,18 @@ func (c *OtelCol) IsCertManagerInstalledByTobs() (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func (c *OtelCol) GetCertManagerVersion() (string, error) {
+	certManagerDeployment, err := c.K8sClient.GetDeployment("cert-manager", "cert-manager")
+	if err != nil {
+		return "", err
+	}
+
+	if val, ok := certManagerDeployment.Labels["app.kubernetes.io/version"]; ok {
+		return val, nil
+	}
+	return "", nil
 }
 
 func (c *OtelCol) CreateDefaultCollector(otelColConfig string) error {


### PR DESCRIPTION
This PR includes

1. Restructure Promscale values for connection details and update the connection details by assigning the `db-passowrd`/`db-uri` to respective value fields so the Promscale helm-chart will perform the DB secret creation. 
2. Delete `jaegerPromscaleQuery` section in `opentelemetryOperator`
3. Delete `otel-collector` CR created by us in the previous version and capture CR from `values.yaml` and re-create it with small changes. 
4. Upgrade `Kube-Prometheus` CRDs.
5. Upgrade `OpenTelemetry-Operator` CRDs.
6. Upgrade `Cert-Manager` if installed by us, by taking the confirmation message from the user. If no other CRs managed by cert-manager is created by the user other than the CRs created by tobs. If found other CRs outside the scope of tobs managed by cert-manager created by tobs. Return below error

```
!!! TOBS UPGRADE NEEDS MANUAL UPGRADE OF CERT_MANAGER RESOURCES: 

As tracing is enabled in tobs, upgrading tobs requires upgrading cert-manager to v1.6.1, The below listed cert-manager certificate resources are not managed by tobs which needs to be manually upgraded using: cmctl utility or using kubectl cert-manager plugin can convert old manifests to v1.

Follow this link for more details: https://cert-manager.io/docs/installation/upgrading/upgrading-1.5-1.6

NAME:    NAMESPACE
...

Error: failed to perform upgrade path to 0.8.0 cert-manager resources not owned by tobs needs a manual upgrade.
```

7. If `cert-manager` is not managed by tobs. Compare the existing `cert-manager` version with the required `cert-manager` version if the cert-manager version is below the required version. Prompt an error stating cert-manager needs to be upgraded. 
8. During install if `cert-manager` exists validate version deployed vs desired if deployed version >= desired version, use the cert-manager present in the cluster. If not log an error during install.  

Fixes: #210 