### PR TITLE
Release 0.9.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for tobs, The Observability Stack for Kubernetes
 
 type: application
 
-version: 0.8.0
-appVersion: 0.8.0
+version: 0.9.0
+appVersion: 0.9.0
 
 dependencies:
   - name: timescaledb-single

--- a/cli/cmd/version/version.go
+++ b/cli/cmd/version/version.go
@@ -9,7 +9,8 @@ import (
 	"github.com/timescale/tobs/cli/pkg/utils"
 )
 
-const tobsVersion = "0.8.0"
+// TODO(paulfantom): read this from VERSION file in the the repository TLD
+const tobsVersion = "0.9.0"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -3,7 +3,7 @@
 set -eu
 
 INSTALLROOT=${INSTALLROOT:-"${HOME}/.local/bin"}
-TOBS_VERSION=${TOBS_VERSION:-0.8.0}
+TOBS_VERSION=${TOBS_VERSION:-0.9.0}
 
 happyexit() {
 	local symlink_msg=""


### PR DESCRIPTION
Bumping dependencies to prepare for 0.9.0 release.

This is blocked by #228