### PR TITLE
*: fix location of goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,2 +1,0 @@
-release:
-  draft: true

--- a/cli/.goreleaser.yml
+++ b/cli/.goreleaser.yml
@@ -27,3 +27,5 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+release:
+  draft: true


### PR DESCRIPTION
Follow-up to #228 as it turned out we have goreleaser config in `cli/` directory.