### PR TITLE
chart: drop explicit tag for timescaledb

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -14,9 +14,6 @@ namespaceOverride: ""
 timescaledb-single:
   # disable the chart if an existing TimescaleDB instance is used
   enabled: &dbEnabled true
-  # TimescaleDB image tag
-  image:
-    tag: pg12-ts2.1-latest
   # create only a ClusterIP service
   loadBalancer:
     enabled: false


### PR DESCRIPTION
By default we should use chart default image. This allows us to set image in one place (timescaledb-single helm chart).