### PR TITLE
.github: add automatic dependency management via renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,19 @@
+{
+  "timezone": "Etc/UTC",
+  "extends": [
+    "config:base",
+    "schedule:daily"
+  ],
+  "packageRules": [
+    {
+      "labels": ["helm"],
+      "groupName": "helm charts",
+      "matchManagers": ["helmv3", "helm-values"]
+    },
+    {
+      "labels": ["cli"],
+      "groupName": "golang",
+      "matchManagers": ["gomod"]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds automatic management of following dependencies:
- helm charts
- golang packages
- github actions

golang packages updates are grouped together and should result in one PR with all updates. The same applies to helm charts. Github actions are not grouped as their update frequency is much lower and it might be better to evaluate each update separatelly.