### PR TITLE
.github: allow renovate to handle github action envs

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,2 +1,0 @@
-golang-version=1.17
-golangci-lint-version=v1.42.1

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,16 +7,34 @@
   "dependencyDashboardLabels": ["dependencies"],
   "dependencyDashboardAutoclose": "true",
   "labels": ["dependencies"],
+  "regexManagers": [
+    {
+      "fileMatch": ".github/workflows/*.yml",
+      "matchStrings": ["golangci-lint-version: (?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "golangci/golangci-lint"
+    },
+    {
+      "fileMatch": ".github/workflows/*.yml",
+      "matchStrings": ["golang-version: (?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "golang-version"
+    }
+  ],
   "packageRules": [
     {
-      "labels": ["helm"],
+      "addLabels": ["helm"],
       "groupName": "helm charts",
       "matchManagers": ["helmv3", "helm-values"]
     },
     {
-      "labels": ["cli"],
+      "addLabels": ["cli"],
       "groupName": "golang",
       "matchManagers": ["gomod"]
+    },
+    {
+      "addLabels": ["github_actions"],
+      "groupName": "github actions",
+      "matchPaths": [".github/**"]
     }
   ]
 }

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: ['**']
 
+env:
+  golang-version: 1.17
+  golangci-lint-version: v1.42.1
+
 jobs:
   build:
     name: Build and Lint
@@ -14,9 +18,6 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-
-      - name: Import environment variables
-        run: cat ".github/env" >> $GITHUB_ENV
 
       - name: Set up Go ${{ env.golang-version }}
         uses: actions/setup-go@v2.2.0
@@ -55,9 +56,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Import environment variables
-        run: cat ".github/env" >> $GITHUB_ENV
-
       - name: Set up Go ${{ env.golang-version }}
         uses: actions/setup-go@v2.2.0
         with:
@@ -85,9 +83,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Import environment variables
-        run: cat ".github/env" >> $GITHUB_ENV
 
       - name: Set up Go ${{ env.golang-version }}
         uses: actions/setup-go@v2.2.0

--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -7,15 +7,15 @@ on:
   pull_request:
     branches: ['**']
 
+env:
+  golang-version: 1.17
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Import environment variables
-        run: cat ".github/env" >> $GITHUB_ENV
 
       - name: Set up Go ${{ env.golang-version }}
         uses: actions/setup-go@v2.2.0

--- a/.github/workflows/tests-schedule.yml
+++ b/.github/workflows/tests-schedule.yml
@@ -10,6 +10,9 @@ defaults:
   run:
     working-directory: cli
 
+env:
+  golang-version: 1.17
+
 jobs:
   golang:
     name: golang
@@ -17,9 +20,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Import environment variables
-        run: cat "../.github/env" >> $GITHUB_ENV
 
       - name: Set up Go ${{ env.golang-version }}
         uses: actions/setup-go@v2.2.0
@@ -47,9 +47,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Import environment variables
-        run: cat "../.github/env" >> $GITHUB_ENV
 
       - name: Set up Go ${{ env.golang-version }}
         uses: actions/setup-go@v2.2.0


### PR DESCRIPTION
This is an extension on what renovate can do.

Few months ago we moved to handing golang and golangci-lint versions across all github action workflow files to a single `.github/env` file. This file was read in each workflow job and simplified managing dependencies.

However, since renovate can update dependencies automatically and allows to do this based on regexes, we can simplify our github action workflow files while still making tools up to date. I've tested a similar functionality with https://github.com/thaum-xyz/ankhmorpork/blob/master/.github/renovate.json and it resulted in [a correct PR](https://github.com/thaum-xyz/ankhmorpork/pull/116)

Small additional change - I found how to set `labels` once and extend it with `addLabels` config. This simplifies managing labels as `dependencies` label doesn't need to be specified everywhere. 