### PR TITLE
.github: set correct depName for renovate regexManager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,7 +17,8 @@
     {
       "fileMatch": ".github/workflows/*.yml",
       "matchStrings": ["golang-version: (?<currentValue>.*?)\\n"],
-      "datasourceTemplate": "golang-version"
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
This wasn't clear when reading documentation, but it became clearer by looking at renovate codebase at https://github.com/renovatebot/renovate/blob/main/lib/datasource/golang-version/index.ts

Fixes #269