### PR TITLE
.github: finetune regex updates via renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,16 +7,23 @@
   "dependencyDashboardLabels": ["dependencies"],
   "dependencyDashboardAutoclose": "true",
   "labels": ["dependencies"],
+  "ignoreDeps": ["k8s.io/client-go"],
   "regexManagers": [
     {
-      "fileMatch": ".github/workflows/*.yml",
-      "matchStrings": ["golangci-lint-version: (?<currentValue>.*?)\\n"],
+      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
+      "matchStrings": ["golangci-lint-version:\\s(?<currentValue>.*?)\\n"],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "golangci/golangci-lint"
     },
     {
-      "fileMatch": ".github/workflows/*.yml",
-      "matchStrings": ["golang-version: (?<currentValue>.*?)\\n"],
+      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
+      "matchStrings": ["helm-version:\\s(?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "helm/helm"
+    },
+    {
+      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
+      "matchStrings": ["golang-version:\\s(?<currentValue>.*?)\\n"],
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "golang"
     }

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -8,7 +8,7 @@ on:
     branches: ['**']
 
 env:
-  golang-version: 1.17
+  golang-version: 1.17.0
   golangci-lint-version: v1.42.1
 
 jobs:

--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -8,7 +8,7 @@ on:
     branches: ['**']
 
 env:
-  golang-version: 1.17
+  golang-version: 1.17.0
 
 jobs:
   goreleaser:

--- a/.github/workflows/helm-releaser.yml
+++ b/.github/workflows/helm-releaser.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: ['*']
 
+env:
+  helm-version: v3.7.1
+
 jobs:
   publish-chart:
      runs-on: ubuntu-latest
@@ -16,7 +19,7 @@ jobs:
        - name: Set up Helm
          uses: azure/setup-helm@v2.0
          with:
-           version: v3.7.1
+           version: ${{ env.helm-version }}
 
        - name: Create package
          env:

--- a/.github/workflows/tests-schedule.yml
+++ b/.github/workflows/tests-schedule.yml
@@ -11,7 +11,7 @@ defaults:
     working-directory: cli
 
 env:
-  golang-version: 1.17
+  golang-version: 1.17.0
 
 jobs:
   golang:


### PR DESCRIPTION
Finalizing what was started in https://github.com/timescale/tobs/pull/268

Logic behind this PR was tested in my fork and resulted in a correct PR as seen in https://github.com/paulfantom/tobs/pull/10

`k8s.io/client-go` is excluded from automatic updates as the project switched to using different version notation which confuses renovatebot.
