### PR TITLE
Bumping timescaledb helm chart to 0.11.0 and adding necessary changes

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -10,7 +10,7 @@ appVersion: 0.8.0
 dependencies:
   - name: timescaledb-single
     condition: timescaledb-single.enabled
-    version: 0.10.0
+    version: 0.11.0
     repository: https://charts.timescale.com
   - name: promscale
     condition: promscale.enabled

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,6 +19,12 @@ timescaledb-single:
     enabled: false
   # number or TimescaleDB pods to spawn (default is 3, 1 for no HA)
   replicaCount: 1
+  secrets:
+    # tobs cli will populate those Secrets
+    # if you don't use CLI, you need to provision them yourself
+    credentialsSecretName: "{{ .Release.Name }}-connection"
+    certificateSecretName: "{{ .Release.Name }}-certificate"
+    pgbackrestSecretName: "{{ .Release.Name }}-pgbackrest"
   # backup is disabled by default, enable it
   # if you want to backup timescaleDB to s3
   # you can provide the s3 details on tobs install


### PR DESCRIPTION
timescaledb helm chart 0.11.0 changed the way it provisions secrets and thus change like this is needed.

This is a quickfix as proper fix would be to switch from provisioning Secret by tobs and use helm to do this. This method is worked on in https://github.com/timescale/tobs/pull/280