### PR TITLE
cli: improve execution time of e2e tests

### DIFF
--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -775,6 +775,7 @@ func (c *upgradeSpec) persistPrometheusDataDuringUpgrade() error {
 	// scale down prometheus replicas to 0
 	fmt.Println("Migrating the underlying prometheus persistent volume to new prometheus instance...")
 	prometheus := root.HelmReleaseName + "-prometheus-server"
+	// FIXME(paulfantom): Test if this even working as Prometheus is not deployed with Deployment object but with CRD.
 	prometheusDeployment, err := c.k8sClient.GetDeployment(prometheus, root.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get %s %v", prometheus, err)

--- a/cli/tests/test-utils/common_utils.go
+++ b/cli/tests/test-utils/common_utils.go
@@ -230,6 +230,7 @@ func (c *TestInstallSpec) TestInstall(t testing.TB) {
 	t.Logf("Running '%v'", "tobs "+strings.Join(cmds, " "))
 	install := exec.Command(PATH_TO_TOBS, cmds...)
 
+	// FIXME(paulfantom): For some reason this is hiding output of the command and thus complicating tests debugging
 	out, err := install.CombinedOutput()
 	if err != nil {
 		t.Logf(string(out))

--- a/cli/tests/tobs-cli-tests/install_backup_enabled_test.go
+++ b/cli/tests/tobs-cli-tests/install_backup_enabled_test.go
@@ -12,7 +12,7 @@ type backupDetails struct {
 	value string
 }
 
-func testBackUpEnabledInstallation(t *testing.T) {
+func testBackupEnabledInstallation(t *testing.T) {
 	t.Log("performing backup enabled tests....")
 	releaseName := "testbackup"
 	namespace := "testbackup"
@@ -56,7 +56,7 @@ func testBackUpEnabledInstallation(t *testing.T) {
 		OnlySecrets:  false,
 	}
 	i.TestInstall(t)
-	sec, err := test_utils.GetTSDBBackUpSecret(releaseName, namespace)
+	sec, err := test_utils.GetTSDBBackupSecret(releaseName, namespace)
 	if err != nil {
 		t.Logf("Error while finding timescaleDB backup secret. After installting tobs with backup enabled.")
 		t.Fatal(err)
@@ -75,7 +75,7 @@ func testBackUpEnabledInstallation(t *testing.T) {
 	}
 	u.TestUninstall(t)
 
-	_, err = test_utils.GetTSDBBackUpSecret(releaseName, namespace)
+	_, err = test_utils.GetTSDBBackupSecret(releaseName, namespace)
 	// here we expect an error after uninstalling the pgbackrest secret shouldn't be found
 	if err == nil {
 		t.Fatal("Uninstalling backup enabled tobs deployment failed to delete pgbackrest secret")


### PR DESCRIPTION
Small code improvements done during working on #280 and #281 which should improve tests resiliency and runtime by swapping static wait time with dynamic polling.

Additionally I've put some code comments for the future for things that need to be checked as they seem incorrect and cause issues.

I've also renamed `BackUp` to `Backup` as the former was a typo.

---
Notes regarding tests (for me or someone else in the future):
- Installation of tobs stack is done in 2 completely different ways in tests
- There is one special test case treating about backup, ideally this should be a separated
- binary is NOT built in tests, which can lead to issues when running tests from IDE