### PR TITLE
chart: use promscale serviceMonitor instead of annotation-based scraping

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -67,6 +67,12 @@ promscale:
     - name: "TOBS_TELEMETRY_TIMESCALEDB_ENABLED"
       value: *dbEnabled
 
+  serviceMonitor:
+    enabled: true
+
+  prometheus:
+    annotations: {}
+
   ## Note:
 
   # If you are providing your own secret name, do

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -71,6 +71,7 @@ promscale:
     enabled: true
 
   prometheus:
+    # turn off annotation-based scraping of promscale itself, user the serviceMonitor instead.
     annotations: {}
 
   ## Note:


### PR DESCRIPTION
As in title

This is building on work done in https://github.com/timescale/promscale/pull/885

Additionally, this will also include promscale alerts when https://github.com/timescale/promscale/pull/1271 is merged, but promscale PR is not blocking this one.

Resolves https://github.com/timescale/o11y-team-applications/issues/186