### PR TITLE
*: deploy otel by default and move deployment of otel collector resource to helm

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,12 @@
     },
     {
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
+      "matchStrings": ["cert-manager-version:\\s(?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "cert-manager/cert-manager"
+    },
+    {
+      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
       "matchStrings": ["golang-version:\\s(?<currentValue>.*?)\\n"],
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "golang"

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -10,6 +10,8 @@ on:
 env:
   golang-version: 1.18.1
   golangci-lint-version: v1.45.2
+  # cert-manager-version needs to be also updated in cli/pkg/otel-utilities.go
+  cert-manager-version: v1.6.1
 
 jobs:
   build:
@@ -89,17 +91,25 @@ jobs:
         with:
           go-version: ${{ env.golang-version }}
 
-      - name: Build
-        working-directory: cli
-        run: |
-          make build
-
       - name: Start kuberenetes cluster
         working-directory: cli
         env:
           KUBE_VERSION: ${{ matrix.kube-version }}
         run: |
           make start-kind
+
+      - name: Install cert-manager
+        working-directory: cli
+        run: |
+          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${{ env.cert-manager-version }}/cert-manager.yaml
+
+      - name: Build
+        working-directory: cli
+        run: |
+          make build
+
+      - name: Wait for cluster to finish bootstraping
+        run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
 
       - name: Helm tests
         working-directory: cli

--- a/chart/README.md
+++ b/chart/README.md
@@ -29,15 +29,11 @@ A Helm chart for deploying Prometheus configured to use TimescaleDB as compresse
 The recommended way to deploy tobs is through the [CLI tool](/cli). However, we also
 support helm deployments that do not use the CLI.
 
-## Creating Secrets
+## Prerequisites
 
-By default, timescaledb helm chart doesn't create its own secrets. So please follow [these instructions][timescaledb-secrets] to create timescaledb-secrets. If you use tobs CLI this is taken care for you.
+Using tobs to install full observability stack with openTelemetry support currently requires installation of cert-manager. To do this please follow [cert-manager documentation](https://cert-manager.io/docs/installation/).
 
-Create timescaledb secrets using `tobs` CLI. This creates database passwords and self-signed certificates.
-
-```
-tobs install --only-secrets --namespace <namepsace>
-```
+_Note_: Using tobs with opentelemetry support disabled doesn't require cert-manager.
 
 ## Installing the helm chart
 
@@ -46,11 +42,10 @@ into your Kubernetes cluster:
 ```
 helm repo add timescale https://charts.timescale.com/
 helm repo update
-helm install <release_name> timescale/tobs promscale.connection.password=<password> 
+helm install --wait <release_name> timescale/tobs
 ```
 
-**Note:** Here the `<password>` should be captured from `<release>-credentials` secret with key `PATRONI_SUPERUSER_PASSWORD`. As the password is created from 
-the above `tobs install --only-secrets` step.
+_Note_: `--wait` flag is necessary for successfull installation as tobs helm chart can create opentelemetry Custom Resources only after opentelemetry-operator is up and running. This flag can be omited when using tobs without opentelemetry support.
 
 # Uninstall
 
@@ -107,7 +102,7 @@ helm show values timescale/tobs > my_values.yml
 You can then edit `my_values.yml` and deploy the release with the following command:
 
 ```
-helm upgrade --install <release_name> --values my_values.yml timescale/tobs
+helm upgrade --wait --install <release_name> --values my_values.yml timescale/tobs
 ```
 
 The properties described in the tables below are only those that this chart overrides for each of the sub-charts it depends on.
@@ -139,7 +134,7 @@ To configure tobs to connect with an external TimescaleDB you need to modify a f
 
 Below is the helm command to disable the TimescaleDB installation and set external db uri details:
 ```
-helm install <release-name> timescale/tobs \
+helm install --wait <release-name> timescale/tobs \
 --set timescaledb-single.enabled=false,promscale.connection.uri=<timescaledb-uri>
 ```
 

--- a/chart/templates/otel-auto-instrumentation.yaml
+++ b/chart/templates/otel-auto-instrumentation.yaml
@@ -2,7 +2,10 @@
 apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
-  name: tobs-auto-instrumentation
+  name: {{ .Release.Name }}-auto-instrumentation
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,pre-delete
+    "helm.sh/hook-weight": "0"
 spec:
   exporter:
     endpoint: http://{{ .Release.Name }}-otel-collector.{{ .Release.Namespace }}.svc:4317

--- a/chart/templates/otel-collector.yaml
+++ b/chart/templates/otel-collector.yaml
@@ -1,0 +1,13 @@
+{{ if and (.Values.opentelemetryOperator.enabled) (.Values.opentelemetryOperator.collector.config) -}}
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: {{ .Release.Name }}-tobs-opentelemetry
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,pre-delete
+    "helm.sh/hook-weight": "0"
+spec:
+  config:
+    {{ tpl (toYaml .Values.opentelemetryOperator.collector.config) $ | nindent 4 }}
+{{- end -}}
+

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -47,7 +47,7 @@ promscale:
   # needs to be enabled for tracing support in Promscale
   # to expose traces port, add tracing args to Promscale
   openTelemetry:
-    enabled: &otelEnabled false
+    enabled: &otelEnabled true
   # to pass extra args
   # extraArgs: []
 
@@ -433,7 +433,7 @@ promlens:
 # Enable OpenTelemetry Operator
 # If using tobs CLI you can enable otel with --enable-opentelemetry flag
 opentelemetryOperator:
-  enabled: false
+  enabled: *otelEnabled
   collector:
     # The default otel collector that will be deployed by CLI once
     # the otel operator is in running state

--- a/cli/pkg/k8s/client_impl.go
+++ b/cli/pkg/k8s/client_impl.go
@@ -1080,7 +1080,11 @@ func (c *clientImpl) buildDynamicResourceClient(data []byte) (obj *unstructured.
 
 	// Some code to define this take from
 	// https://github.com/kubernetes/cli-runtime/blob/master/pkg/genericclioptions/config_flags.go#L215
-	cacheDir := "$HOME/.cache/tobs"
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+	cacheDir := homeDir + "/.cache/tobs"
 	httpCacheDir := filepath.Join(cacheDir, "http")
 	discoveryCacheDir := computeDiscoverCacheDir(filepath.Join(cacheDir, "discovery"), config.Host)
 

--- a/cli/tests/helm-tests/helm_test.go
+++ b/cli/tests/helm-tests/helm_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/timescale/tobs/cli/pkg/helm"
@@ -94,6 +95,8 @@ func testHelmClientInstallOrUpgradeChart() {
 		Namespace:       NAMESPACE,
 		Version:         tobsVersion,
 		CreateNamespace: true,
+		Wait:            true,
+		Timeout:         15 * time.Minute,
 		ValuesFiles:     []string{PATH_TO_TEST_VALUES},
 	}
 

--- a/cli/tests/installation-tests/installation_test.go
+++ b/cli/tests/installation-tests/installation_test.go
@@ -66,7 +66,6 @@ func TestInstallation(t *testing.T) {
 		Namespace:    NAMESPACE,
 		PathToValues: PATH_TO_TEST_VALUES,
 		EnableBackUp: false,
-		SkipWait:     true,
 		OnlySecrets:  false,
 	}
 	abcInstall.TestInstall(t)
@@ -86,7 +85,6 @@ func TestInstallation(t *testing.T) {
 		Namespace:    NAMESPACE,
 		PathToValues: PATH_TO_TEST_VALUES,
 		EnableBackUp: false,
-		SkipWait:     true,
 		OnlySecrets:  false,
 	}
 	defInstall.TestInstall(t)
@@ -114,7 +112,6 @@ func TestInstallation(t *testing.T) {
 		Namespace:    NAMESPACE,
 		PathToValues: "./../testdata/f1.yaml",
 		EnableBackUp: false,
-		SkipWait:     true,
 		OnlySecrets:  false,
 	}
 	f1Install.TestInstall(t)
@@ -134,7 +131,6 @@ func TestInstallation(t *testing.T) {
 		Namespace:    NAMESPACE,
 		PathToValues: "./../testdata/f2.yaml",
 		EnableBackUp: false,
-		SkipWait:     true,
 		OnlySecrets:  false,
 	}
 	f2Install.TestInstall(t)
@@ -153,7 +149,6 @@ func TestInstallation(t *testing.T) {
 		Namespace:    "secrets",
 		PathToValues: PATH_TO_TEST_VALUES,
 		EnableBackUp: false,
-		SkipWait:     true,
 		OnlySecrets:  true,
 	}
 	f5Install.TestInstall(t)
@@ -179,7 +174,6 @@ func TestInstallation(t *testing.T) {
 		Namespace:    NAMESPACE,
 		PathToValues: PATH_TO_TEST_VALUES,
 		EnableBackUp: false,
-		SkipWait:     false,
 		OnlySecrets:  false,
 	}
 	dInstall.TestInstall(t)

--- a/cli/tests/test-utils/common_utils.go
+++ b/cli/tests/test-utils/common_utils.go
@@ -215,7 +215,6 @@ type TestInstallSpec struct {
 	Namespace    string
 	PathToValues string
 	EnableBackUp bool
-	SkipWait     bool
 	OnlySecrets  bool
 }
 
@@ -229,9 +228,6 @@ func (c *TestInstallSpec) TestInstall(t testing.TB) {
 	cmds := []string{"install", "--chart-reference", c.PathToChart, "--name", c.ReleaseName, "--namespace", c.Namespace}
 	if c.EnableBackUp {
 		cmds = append(cmds, "--enable-timescaledb-backup")
-	}
-	if c.SkipWait {
-		cmds = append(cmds, "--skip-wait")
 	}
 	if c.PathToValues != "" {
 		cmds = append(cmds, "-f", c.PathToValues)

--- a/cli/tests/testdata/e2e-values.yaml
+++ b/cli/tests/testdata/e2e-values.yaml
@@ -53,6 +53,9 @@ promscale:
     host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
     port: 5432
 
+  openTelemetry:
+    enabled: true
+
   extraEnv:
     - name: "TOBS_TELEMETRY_INSTALLED_BY"
       value: "helm"
@@ -385,7 +388,7 @@ promlens:
 # Enable OpenTelemetry Operator
 # If using tobs CLI you can enable otel with --enable-opentelemetry flag
 opentelemetryOperator:
-  enabled: false
+  enabled: true
   jaeger:
     image: jaegertracing/jaeger-query:1.30
     args:

--- a/cli/tests/tobs-cli-tests/concurrent_test.go
+++ b/cli/tests/tobs-cli-tests/concurrent_test.go
@@ -55,7 +55,6 @@ func TestConcurrent(t *testing.T) {
 		Namespace:    NAMESPACE,
 		PathToValues: PATH_TO_TEST_VALUES,
 		EnableBackUp: false,
-		SkipWait:     true,
 		OnlySecrets:  false,
 	}
 	i1.TestInstall(t)
@@ -67,7 +66,6 @@ func TestConcurrent(t *testing.T) {
 		Namespace:    NAMESPACE,
 		PathToValues: PATH_TO_TEST_VALUES,
 		EnableBackUp: false,
-		SkipWait:     true,
 		OnlySecrets:  false,
 	}
 	i2.TestInstall(t)
@@ -108,7 +106,6 @@ func TestConcurrent(t *testing.T) {
 		Namespace:    NAMESPACE,
 		PathToValues: PATH_TO_TEST_VALUES,
 		EnableBackUp: false,
-		SkipWait:     true,
 		OnlySecrets:  false,
 	}
 	i3.TestInstall(t)


### PR DESCRIPTION
Few things are done in this PR:
- `--tracing` flag is deprecated, but still present
- tracing is enabled by default (fixes https://github.com/timescale/o11y-team-applications/issues/161)
- otel collector CR is deployed with helm instead of artisan deployment in tobs CLI

This PR is based on top of https://github.com/timescale/tobs/pull/305 and as such it is created as a draft.