### PR TITLE
chart: use timescaledb 2.6.1 on postgres 14

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -14,6 +14,12 @@ namespaceOverride: ""
 timescaledb-single:
   # disable the chart if an existing TimescaleDB instance is used
   enabled: &dbEnabled true
+
+  image:
+    repository: timescale/timescaledb-ha
+    tag: pg12-ts2.0.0-p0
+    pullPolicy: IfNotPresent
+
   # create only a ClusterIP service
   loadBalancer:
     enabled: false


### PR DESCRIPTION
This PR is a fall-back if https://github.com/timescale/timescaledb-kubernetes/pull/360 won't get merged.