### PR TITLE
chart: disable otel compression

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -453,6 +453,7 @@ opentelemetryOperator:
         logging:
         otlp:
           endpoint: "{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9202"
+          compression: none
           tls:
             insecure: true
         prometheusremotewrite:


### PR DESCRIPTION
Right now promscale does not support compression, so tobs should disable compression by default.

Spawned from https://github.com/timescale/promscale/issues/1292