### PR TITLE
*: remove all cluster.local suffixes

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -147,7 +147,7 @@ helm install --wait <release-name> timescale/tobs \
 | `promscale.connection.user`              | User used for connection to db | `postgres` |
 | `promscale.connection.uri`               | TimescaleDB URI | `` |
 | `promscale.connection.password`          | Assign the TimescaleDB password from `tobs-credentials` from key `PATRONI_SUPERUSER_PASSWORD` | `` |
-| `promscale.connection.host`              | TimescaleDB host address | `"{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"` |
+| `promscale.connection.host`              | TimescaleDB host address | `"{{ .Release.Name }}.{{ .Release.Namespace }}.svc"` |
 | `promscale.service.type`                 | Configure the service type for Promscale | `ClusterIP`     |
 | `promscale.resources.requests.memory`    | Amount of memory for the Promscale pod                | `2Gi`       |
 | `promscale.resources.requests.cpu`       | Number of vCPUs for the Promscale pod                 | `1`         |
@@ -173,8 +173,8 @@ For more details about how to configure the Promscale please see the
 | `kube-prometheus-stack.prometheus.prometheusSpec.scrapeTimeout` | Prometheus scrape timeout |      `10s` |
 | `kube-prometheus-stack.prometheus.prometheusSpec.evaluationInterval` | Prometheus evaluation interval |    `1m` |
 | `kube-prometheus-stack.prometheus.prometheusSpec.retention` | Prometheus data retention |    `1d` |
-| `kube-prometheus-stack.prometheus.prometheusSpec.remoteRead` | Prometheus remote read config |  `url: http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/read` and `readRecent: true` |
-| `kube-prometheus-stack.prometheus.prometheusSpec.remoteWrite` | Prometheus remote write config |  `url: http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/write` |
+| `kube-prometheus-stack.prometheus.prometheusSpec.remoteRead` | Prometheus remote read config |  `url: http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/read` and `readRecent: true` |
+| `kube-prometheus-stack.prometheus.prometheusSpec.remoteWrite` | Prometheus remote write config |  `url: http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/write` |
 | `kube-prometheus-stack.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage` | Prometheus persistent volume storage |  `8Gi` |
 | `kube-prometheus-stack.prometheus.prometheusSpec.additionalScrapeConfigs` | Prometheus additional scrape config, By default additional scrape config is set scrape all pods, services and endpoint with prometheus annotations  |   |
 
@@ -205,15 +205,15 @@ For more information about the `remote_write` configuration that can be set with
 | `kube-prometheus-stack.grafana.sidecar.dashboards.enabled`          | If false, no dashboards will be provisioned by default | `true`     |
 | `kube-prometheus-stack.grafana.sidecar.dashboards.files`            | Files with dashboard definitions (in JSON) to be provisioned | `['dashboards/k8s-cluster.json','dashboards/k8s-hardware.json']` |
 | `kube-prometheus-stack.grafana.prometheus.datasource.enabled`       | If false, a Prometheus data source will not be provisioned | true |
-| `kube-prometheus-stack.grafana.prometheus.datasource.url`           | Template parsed to the url of the Prometheus API. Defaults to Prometheus deployed with this chart  | `http://{{ .Release.Name }}-prometheus-service.{{ .Release.Namespace }}.svc.cluster.local` |
+| `kube-prometheus-stack.grafana.prometheus.datasource.url`           | Template parsed to the url of the Prometheus API. Defaults to Prometheus deployed with this chart  | `http://{{ .Release.Name }}-prometheus-service.{{ .Release.Namespace }}.svc` |
 | `kube-prometheus-stack.grafana.timescale.database.enabled`          | If false, TimescaleDB will not be configured as a database, default sqllite will be used | `true` |
-| `kube-prometheus-stack.grafana.timescale.database.host`             | Hostname (templated) of database, defaults to db deployed with this chart | `"{{ .Release.Name }}.{{ .Release.Namespace}}.svc.cluster.local` |
+| `kube-prometheus-stack.grafana.timescale.database.host`             | Hostname (templated) of database, defaults to db deployed with this chart | `"{{ .Release.Name }}.{{ .Release.Namespace}}.svc` |
 | `kube-prometheus-stack.grafana.timescale.database.user`             | User to connect to the db with (will be created ) | `grafanadb` |
 | `kube-prometheus-stack.grafana.timescale.database.pass`             | Password for the user | `grafanadb` |
 | `kube-prometheus-stack.grafana.timescale.database.dbName`           | Database where to store the data | `postgres` |
 | `kube-prometheus-stack.grafana.timescale.database.schema`           | Schema to use (will be created) | `grafanadb` |
 | `kube-prometheus-stack.grafana.timescale.database.sslMode`          | SSL mode for connection | `require` |
-| `kube-prometheus-stack.grafana.timescale.datasource.host`           | Hostname (templated) of database, defaults to host deployed with this chart | `"{{ .Release.Name }}.{{ .Release.Namespace}}.svc.cluster.local` |
+| `kube-prometheus-stack.grafana.timescale.datasource.host`           | Hostname (templated) of database, defaults to host deployed with this chart | `"{{ .Release.Name }}.{{ .Release.Namespace}}.svc` |
 | `kube-prometheus-stack.grafana.timescale.datasource.enabled`        | If false a TimescaleDB data source will not be provisioned | `true` |
 | `kube-prometheus-stack.grafana.timescale.datasource.user`           | User to connect with | `grafana` |
 | `kube-prometheus-stack.grafana.timescale.datasource.pass`           | Pass for user | `grafana` |

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -32,7 +32,7 @@
 ###############################################################################
 {{ if $prometheus.enabled }}
 Prometheus can be accessed via port {{ $prometheus.service.port }} on the following DNS name from within your cluster:
-{{ $kubePrometheus.fullnameOverride }}-prometheus.{{ .Release.Namespace }}.svc.cluster.local
+{{ $kubePrometheus.fullnameOverride }}-prometheus.{{ .Release.Namespace }}.svc
 {{ if $prometheus.ingress.enabled -}}
 Server URL(s) from outside the cluster:
 {{- range $prometheus.ingress.hosts }}
@@ -70,7 +70,7 @@ WARNING! Persistence is disabled on Prometheus server
 
 {{ if $kubePrometheus.alertmanager.enabled }}
 The Prometheus alertmanager can be accessed via port {{ $kubePrometheus.alertmanager.service.port }} on the following DNS name from within your cluster:
-{{ $kubePrometheus.fullnameOverride }}-alertmanager.{{ .Release.Namespace }}.svc.cluster.local
+{{ $kubePrometheus.fullnameOverride }}-alertmanager.{{ .Release.Namespace }}.svc
 
 {{ if $kubePrometheus.alertmanager.ingress.enabled -}}
 From outside the cluster, the alertmanager URL(s) are:
@@ -114,7 +114,7 @@ WARNING! Persistence is disabled on AlertManager.
 {{- if index .Values "timescaledb-single" "enabled" }}
 
 TimescaleDB can be accessed via port 5432 on the following DNS name from within your cluster:
-{{ template "clusterName" $tsEnv }}.{{ .Release.Namespace }}.svc.cluster.local
+{{ template "clusterName" $tsEnv }}.{{ .Release.Namespace }}.svc
 {{- else }}
 
 Connecting to an external TimescaleDB, As external DB URI has been configured during the installation.
@@ -144,13 +144,13 @@ To connect to your database, chose one of these options:
     kubectl run -i --tty --rm psql --image=postgres \
       --env "PGPASSWORD=$PGPASSWORD_POSTGRES" \
       --command -- psql -U postgres \
-      -h {{ template "clusterName" $tsEnv }}.{{ .Release.Namespace }}.svc.cluster.local postgres
+      -h {{ template "clusterName" $tsEnv }}.{{ .Release.Namespace }}.svc postgres
 
     # login as admin
     kubectl run -i --tty --rm psql --image=postgres \
       --env "PGPASSWORD=$PGPASSWORD_ADMIN" \
       --command -- psql -U admin \
-      -h {{ template "clusterName" $tsEnv }}.{{ .Release.Namespace }}.svc.cluster.local postgres
+      -h {{ template "clusterName" $tsEnv }}.{{ .Release.Namespace }}.svc postgres
 {{- end }}
 
 2. Directly execute a psql session on the master node
@@ -192,7 +192,7 @@ To connect to your database, chose one of these options:
     The OpenTelemetry collector is deployed to collect traces.
 
     OpenTelemetry collector can be accessed with the following DNS name from within your cluster:
-    {{ .Release.Name }}-opentelemetry-collector.{{ .Release.Namespace }}.svc.cluster.local
+    {{ .Release.Name }}-opentelemetry-collector.{{ .Release.Namespace }}.svc
 
 {{- end -}}
 
@@ -204,7 +204,7 @@ To connect to your database, chose one of these options:
 
 1. The Grafana server can be accessed via port {{ $grafana.service.port }} on
    the following DNS name from within your cluster:
-   {{ .Release.Name }}-grafana.{{ .Release.Namespace  }}.svc.cluster.local
+   {{ .Release.Name }}-grafana.{{ .Release.Namespace  }}.svc
 
    You can access grafana locally by executing:
 {{- if .Values.cli }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -99,7 +99,7 @@ promscale:
     password: ""
     # Host name (templated) of the database instance, default
     # to service created in timescaledb-single
-    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
+    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc"
     port: 5432
     sslMode: require
 
@@ -128,13 +128,13 @@ kube-prometheus-stack:
       # ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotereadspec
       remoteRead:
         # - {protocol}://{host}:{port}/{endpoint}
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/read"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/read"
           readRecent: true
 
       # The remote_write spec configuration for Prometheus.
       # ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotewritespec
       remoteWrite:
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/write"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/write"
 
       # Prometheus pod storage spec
       storageSpec:
@@ -376,7 +376,7 @@ kube-prometheus-stack:
         # By default url of data source is set to ts-prom connector instance
         # deployed with this chart. If a connector isn't used this should be
         # set to the prometheus-server.
-        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201"
+        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201"
     timescale:
       database:
         enabled: true
@@ -400,7 +400,7 @@ kube-prometheus-stack:
       adminUser: postgres
       adminPassSecret: "{{ .Release.Name }}-promscale"
     jaeger:
-      promscaleTracesQueryEndPoint: "{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9202"
+      promscaleTracesQueryEndPoint: "{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9202"
 
   # By default kube-state-metrics are scraped using
   # serviceMonitor disable annotation based scraping
@@ -452,12 +452,12 @@ opentelemetryOperator:
       exporters:
         logging:
         otlp:
-          endpoint: "{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9202"
+          endpoint: "{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9202"
           compression: none
           tls:
             insecure: true
         prometheusremotewrite:
-          endpoint: "{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/write"
+          endpoint: "{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/write"
           tls:
             insecure: true
 

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -270,7 +270,7 @@ promscale:
 		config = config + fmt.Sprintf(`
   connection:
     password: %s
-    host: %s.%s.svc.cluster.local`, dbPassword, cmd.HelmReleaseName, cmd.Namespace)
+    host: %s.%s.svc`, dbPassword, cmd.HelmReleaseName, cmd.Namespace)
 	}
 
 	if args != "" {

--- a/cli/cmd/timescaledb/connect.go
+++ b/cli/cmd/timescaledb/connect.go
@@ -89,7 +89,7 @@ func PsqlConnect(k8sClient k8s.Client, dbDetails *pgconn.DBDetails, master bool)
 		return err
 	}
 	if uri == "" {
-		host = root.HelmReleaseName + "." + root.Namespace + ".svc.cluster.local"
+		host = root.HelmReleaseName + "." + root.Namespace + ".svc"
 		psqlCMD = "psql -U " + dbDetails.User + " -h " + host + " " + dbDetails.DBName
 	} else {
 		psqlCMD = "psql " + uri

--- a/cli/tests/testdata/chart1/values.yaml
+++ b/cli/tests/testdata/chart1/values.yaml
@@ -49,7 +49,7 @@ promscale:
     # user to connect to TimescaleDB with
     user: postgres
     password: ""
-    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
+    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc"
     port: 5432
 #  resources:
 #    requests:
@@ -73,13 +73,13 @@ kube-prometheus-stack:
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotereadspec
       remoteRead:
         # - {protocol}://{host}:{port}/{endpoint}
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/read"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/read"
           readRecent: true
 
       ## The remote_write spec configuration for Prometheus.
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotewritespec
       remoteWrite:
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/write"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/write"
 
       ## Prometheus pod storage spec
       storageSpec:
@@ -118,7 +118,7 @@ kube-prometheus-stack:
         # By default url of data source is set to ts-prom connector instance
         # deployed with this chart. If a connector isn't used this should be
         # set to the prometheus-server.
-        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201"
+        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201"
     timescale:
       database:
         enabled: true

--- a/cli/tests/testdata/chart2/values.yaml
+++ b/cli/tests/testdata/chart2/values.yaml
@@ -49,7 +49,7 @@ promscale:
     # user to connect to TimescaleDB with
     user: postgres
     password: ""
-    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
+    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc"
     port: 5432
 
   # configuration options for the service exposed by promscale
@@ -76,13 +76,13 @@ kube-prometheus-stack:
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotereadspec
       remoteRead:
         # - {protocol}://{host}:{port}/{endpoint}
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/read"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/read"
           readRecent: true
 
       ## The remote_write spec configuration for Prometheus.
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotewritespec
       remoteWrite:
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/write"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/write"
 
       ## Prometheus pod storage spec
       storageSpec:
@@ -121,7 +121,7 @@ kube-prometheus-stack:
         # By default url of data source is set to ts-prom connector instance
         # deployed with this chart. If a connector isn't used this should be
         # set to the prometheus-server.
-        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201"
+        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201"
     timescale:
       database:
         enabled: true

--- a/cli/tests/testdata/e2e-values.yaml
+++ b/cli/tests/testdata/e2e-values.yaml
@@ -50,7 +50,7 @@ promscale:
     # user to connect to TimescaleDB with
     user: postgres
     password: ""
-    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
+    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc"
     port: 5432
 
   openTelemetry:
@@ -97,13 +97,13 @@ kube-prometheus-stack:
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotereadspec
       remoteRead:
         # - {protocol}://{host}:{port}/{endpoint}
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/read"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/read"
           readRecent: true
 
       ## The remote_write spec configuration for Prometheus.
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotewritespec
       remoteWrite:
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/write"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/write"
 
       ## Prometheus pod storage spec
       storageSpec:
@@ -332,7 +332,7 @@ kube-prometheus-stack:
         # By default url of data source is set to ts-prom connector instance
         # deployed with this chart. If a connector isn't used this should be
         # set to the prometheus-server.
-        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201"
+        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201"
     timescale:
       database:
         enabled: true
@@ -356,7 +356,7 @@ kube-prometheus-stack:
       adminUser: postgres
       adminPassSecret: "{{ .Release.Name }}-promscale"
     jaeger:
-      promscaleTracesQueryEndPoint: "{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9202"
+      promscaleTracesQueryEndPoint: "{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9202"
 
   # By default kube-state-metrics are scraped using
   # serviceMonitor disable annotation based scraping
@@ -392,7 +392,7 @@ opentelemetryOperator:
   jaeger:
     image: jaegertracing/jaeger-query:1.30
     args:
-      - --grpc-storage.server={{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9202
+      - --grpc-storage.server={{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9202
       - --grpc-storage.tls.enabled=false
       - --grpc-storage.connection-timeout=1h
     env:

--- a/cli/tests/testdata/f1.yaml
+++ b/cli/tests/testdata/f1.yaml
@@ -35,7 +35,7 @@ promscale:
     # user to connect to TimescaleDB with
     user: postgres
     password: ""
-    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
+    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc"
 
 # Enabling Kube-Prometheus will install
 # Grafana & Prometheus into tobs as they
@@ -51,13 +51,13 @@ kube-prometheus-stack:
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotereadspec
       remoteRead:
         # - {protocol}://{host}:{port}/{endpoint}
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/read"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/read"
           readRecent: true
 
       ## The remote_write spec configuration for Prometheus.
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotewritespec
       remoteWrite:
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/write"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/write"
 
       ## Prometheus pod storage spec
       storageSpec:
@@ -96,7 +96,7 @@ kube-prometheus-stack:
         # By default url of data source is set to ts-prom connector instance
         # deployed with this chart. If a connector isn't used this should be
         # set to the prometheus-server.
-        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201"
+        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201"
     timescale:
       database:
         enabled: true

--- a/cli/tests/testdata/f2.yaml
+++ b/cli/tests/testdata/f2.yaml
@@ -35,7 +35,7 @@ promscale:
     # user to connect to TimescaleDB with
     user: postgres
     password: ""
-    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
+    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc"
 
 # Enabling Kube-Prometheus will install
 # Grafana & Prometheus into tobs as they
@@ -51,13 +51,13 @@ kube-prometheus-stack:
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotereadspec
       remoteRead:
         # - {protocol}://{host}:{port}/{endpoint}
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/read"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/read"
           readRecent: true
 
       ## The remote_write spec configuration for Prometheus.
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotewritespec
       remoteWrite:
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/write"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/write"
 
       ## Prometheus pod storage spec
       storageSpec:
@@ -96,7 +96,7 @@ kube-prometheus-stack:
         # By default url of data source is set to ts-prom connector instance
         # deployed with this chart. If a connector isn't used this should be
         # set to the prometheus-server.
-        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201"
+        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201"
     timescale:
       database:
         enabled: true

--- a/cli/tests/testdata/f3.yaml
+++ b/cli/tests/testdata/f3.yaml
@@ -41,7 +41,7 @@ promscale:
     # user to connect to TimescaleDB with
     user: postgres
     password: ""
-    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
+    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc"
     port: 5432
 
 #  resources:
@@ -65,13 +65,13 @@ kube-prometheus-stack:
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotereadspec
       remoteRead:
         # - {protocol}://{host}:{port}/{endpoint}
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/read"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/read"
           readRecent: true
 
       ## The remote_write spec configuration for Prometheus.
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotewritespec
       remoteWrite:
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/write"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/write"
 
       ## Prometheus pod storage spec
       storageSpec:
@@ -110,7 +110,7 @@ kube-prometheus-stack:
         # By default url of data source is set to ts-prom connector instance
         # deployed with this chart. If a connector isn't used this should be
         # set to the prometheus-server.
-        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201"
+        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201"
     timescale:
       database:
         enabled: true

--- a/cli/tests/testdata/f4.yaml
+++ b/cli/tests/testdata/f4.yaml
@@ -49,7 +49,7 @@ promscale:
     # user to connect to TimescaleDB with
     user: postgres
     password: ""
-    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
+    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc"
     port: 5432
 
   resources:
@@ -72,13 +72,13 @@ kube-prometheus-stack:
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotereadspec
       remoteRead:
         # - {protocol}://{host}:{port}/{endpoint}
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/read"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/read"
           readRecent: true
 
       ## The remote_write spec configuration for Prometheus.
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotewritespec
       remoteWrite:
-        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201/write"
+        - url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201/write"
 
       ## Prometheus pod storage spec
       storageSpec:
@@ -117,7 +117,7 @@ kube-prometheus-stack:
         # By default url of data source is set to ts-prom connector instance
         # deployed with this chart. If a connector isn't used this should be
         # set to the prometheus-server.
-        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc.cluster.local:9201"
+        url: "http://{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201"
     timescale:
       database:
         enabled: true


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

`.cluster.local` suffix is not necessary in kubernetes environment and can cause issues when folks change cluster DNS name.

The only downside of removing this suffix is a bit more work put on DNS server, but in this case I think better user experience is worth this.

Fixes https://github.com/timescale/tobs/issues/327

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Remove cluster.local suffixes from urls
```