### PR TITLE
chart: bump promscale chart version and pin timescaledb image to dev one

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     repository: https://charts.timescale.com
   - name: promscale
     condition: promscale.enabled
-    version: 0.10.0
+    version: 0.11.0-alpha.1
     repository: https://charts.timescale.com
   - name: kube-prometheus-stack
     condition: kube-prometheus-stack.enabled

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -14,6 +14,15 @@ namespaceOverride: ""
 timescaledb-single:
   # disable the chart if an existing TimescaleDB instance is used
   enabled: &dbEnabled true
+  
+  # TODO(paulfantom): switch to official image before 0.10.0 release
+  image:
+    #repository: timescale/timescaledb-ha
+    #tag: pg14.2-ts2.6.1-p3
+    repository: ghcr.io/timescale/dev_promscale_extension
+    tag: 0.5.0-alpha-ts2-pg14
+    pullPolicy: IfNotPresent
+
   # create only a ClusterIP service
   loadBalancer:
     enabled: false
@@ -43,13 +52,14 @@ timescaledb-single:
 #   https://github.com/timescale/promscale/tree/master/helm-chart
 promscale:
   enabled: true
-  image: timescale/promscale:0.10.0
+  image: timescale/promscale:0.11.0-alpha.1
   # needs to be enabled for tracing support in Promscale
   # to expose traces port, add tracing args to Promscale
   openTelemetry:
     enabled: &otelEnabled true
   # to pass extra args
-  # extraArgs: []
+  extraArgs:
+    - "-startup.upgrade-prerelease-extensions"
 
   extraEnv:
     - name: "TOBS_TELEMETRY_INSTALLED_BY"


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

- Bumping promscale to use alpha version for testing

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Switching to promscale 0.11.0 which requires timescaleDB
```