### PR TITLE
chart: fix inclusion of promscale dashboards in tobs

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -368,6 +368,12 @@ kube-prometheus-stack:
         files:
           - dashboards/k8s-cluster.json
           - dashboards/k8s-hardware.json
+          - dashboards/apm-dependencies.json
+          - dashboards/apm-home.json
+          - dashboards/apm-service-dependencies-downstream.json
+          - dashboards/apm-service-dependencies-upstream.json
+          - dashboards/apm-service-overview.json
+          - dashboards/promscale.json
     adminPassword: ""
     envFromSecret: "{{ .Release.Name }}-grafana-db"
     prometheus:


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

We included dashboards in few places, but they were still not showing up in grafana. This PR should change it and allow grafana sidecar to pick up APM dashboards.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix inclusion of APM dashboards
```