### PR TITLE
cli: tracing flag deprecation notice

### DIFF
--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -36,7 +36,7 @@ func addInstallUtilitiesFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("version", "", "", "Option to provide tobs helm chart version, if not provided will install the latest tobs chart available")
 	cmd.Flags().BoolP("skip-wait", "", false, "[DEPRECATED] flag is not functional as tobs installation requires waiting for pods to be in running state due to opentelemetry prerequisities")
 	cmd.Flags().BoolP("enable-prometheus-ha", "", false, "Option to enable prometheus and promscale high-availability, by default scales to 2 replicas")
-	cmd.Flags().BoolP("tracing", "", false, "Option to enable OpenTelemetry and Jaeger components")
+	cmd.Flags().BoolP("tracing", "", false, "[DEPRECATED] flag is not functional as tobs is installing tracing support by default")
 	cmd.Flags().StringP("external-timescaledb-uri", "e", "", "Connect to an existing db using the provided URI")
 	cmd.Flags().BoolP("confirm", "y", false, "Confirmation for all user input prompts")
 }
@@ -85,7 +85,7 @@ func helmInstall(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not install The Observability Stack: %w", err)
 	}
 
-	// TODO(paulfantom): Remove deprecated flags post 0.11.0 release
+	// TODO(paulfantom): Remove deprecated flags post 0.10.0 release
 	if cmd.Flags().Changed("tracing") {
 		fmt.Println("DEPRECATED flag used: 'tracing'. This flag will be removed in future versions of tobs. Feature is now enabled by default and if you want to disable deployment of opentelemetry-operator, change value of opentelemetryOperator.enabled")
 	}


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

- Make it clearer that `--tracing` will be deprecated.
- Change deprecation date to post 0.10.0 release (we wanted to deprecate in release after the one we do tomorrow, not in 2 releases time).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```