### PR TITLE
chore: adjust goreleaser to use more meaningful changelog format

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+<!-- 
+Changelog entry
+
+We are using GitHub to generate changelog in each release note. This method takes PR title and uses it as a changelog line. For this reason we ask you to use meaningful PR titles.
+-->
+
 ## Description
 
 <!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
@@ -5,27 +11,10 @@
 
 ## Type of change
 
-*What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply.*
+*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*
 
 - [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
 - [ ] `FEATURE` (non-breaking change which adds functionality)
 - [ ] `BUGFIX` (non-breaking change which fixes an issue)
 - [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
 - [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
-
-## Changelog entry
-
-*Please put a one-line changelog entry below. This will be copied to the changelog file during the release process.*
-
-<!-- 
-Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
-the technical details of your PR, so consider what they need to know when you write your release note.
-
-Some brief examples of release notes:
-- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
-- Generate correct scraping configuration for Probes with empty or unset module parameter.
--->
-
-```release-note
-
-```

--- a/cli/.goreleaser.yml
+++ b/cli/.goreleaser.yml
@@ -22,10 +22,6 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
-  sort: asc
-  filters:
-    exclude:
-    - '^docs:'
-    - '^test:'
+  use: github
 release:
   draft: true


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

- changing goreleaser config to use github changelog format
- changing goreleaser config to allow closing milestones
- Fixing PR template to allow better usage of goreleaser changelog format

## Type of change

*What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
