### PR TITLE
.github: create milestones only for minor releases, not for patches

### DIFF
--- a/.github/workflows/project-management.yml
+++ b/.github/workflows/project-management.yml
@@ -49,6 +49,6 @@ jobs:
         id: createmilestone
         uses: "WyriHaximus/github-action-create-milestone@v1"
         with:
-          title: ${{ steps.semvers.outputs.patch }}
+          title: ${{ steps.semvers.outputs.minor }}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
<!-- 
Changelog entry

We are using GitHub to generate changelog in each release note. This method takes PR title and uses it as a changelog line. For this reason we ask you to use meaningful PR titles.
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

As in title.

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
