### PR TITLE
cli/cmd/install: remove deprecated flags and hard exit on their usage

### DIFF
--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -29,14 +29,9 @@ func init() {
 }
 
 func addInstallUtilitiesFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolP("only-secrets", "", false, "[DEPRECATED] Defunct flag historically used to create TimescaleDB secrets")
-	cmd.Flags().StringP("timescaledb-tls-cert", "", "", "[DEPRECATED] Use helm values file to configure TLS certificate. This option can be configured with either 'timescaledb-single.secrets.certificate' or 'timescaledb-single.secrets.certificateSecretName'")
-	cmd.Flags().StringP("timescaledb-tls-key", "", "", "[DEPRECATED] Use helm values file to configure TLS certificate. This option can be configured with either 'timescaledb-single.secrets.certificate' or 'timescaledb-single.secrets.certificateSecretName'")
 	cmd.Flags().BoolP("enable-timescaledb-backup", "b", false, "Option to enable TimescaleDB S3 backup")
 	cmd.Flags().StringP("version", "", "", "Option to provide tobs helm chart version, if not provided will install the latest tobs chart available")
-	cmd.Flags().BoolP("skip-wait", "", false, "[DEPRECATED] flag is not functional as tobs installation requires waiting for pods to be in running state due to opentelemetry prerequisities")
 	cmd.Flags().BoolP("enable-prometheus-ha", "", false, "Option to enable prometheus and promscale high-availability, by default scales to 2 replicas")
-	cmd.Flags().BoolP("tracing", "", false, "[DEPRECATED] flag is not functional as tobs is installing tracing support by default")
 	cmd.Flags().StringP("external-timescaledb-uri", "e", "", "Connect to an existing db using the provided URI")
 	cmd.Flags().BoolP("confirm", "y", false, "Confirmation for all user input prompts")
 }
@@ -83,23 +78,6 @@ func helmInstall(cmd *cobra.Command, args []string) error {
 	i.ConfirmActions, err = cmd.Flags().GetBool("confirm")
 	if err != nil {
 		return fmt.Errorf("could not install The Observability Stack: %w", err)
-	}
-
-	// TODO(paulfantom): Remove deprecated flags post 0.10.0 release
-	if cmd.Flags().Changed("tracing") {
-		fmt.Println("DEPRECATED flag used: 'tracing'. This flag will be removed in future versions of tobs. Feature is now enabled by default and if you want to disable deployment of opentelemetry-operator, change value of opentelemetryOperator.enabled")
-	}
-	if cmd.Flags().Changed("skip-wait") {
-		fmt.Println("DEPRECATED flag used: 'skip-wait'. This flag will be removed in future versions of tobs. Feature is now disabled by default to allow smooth installation of opentelemetry components")
-	}
-	if cmd.Flags().Changed("only-secrets") {
-		fmt.Println("DEPRECATED flag used: 'only-secrets'. This flag will be removed in future versions of tobs.")
-	}
-	if cmd.Flags().Changed("timescaledb-tls-cert") {
-		fmt.Println("DEPRECATED flag used: 'timescaledb-tls-cert'. This flag will be removed in future versions of tobs. Use helm values file to configure TLS certificate. This option can be configured with either 'timescaledb-single.secrets.certificate' or 'timescaledb-single.secrets.certificateSecretName'")
-	}
-	if cmd.Flags().Changed("timescaledb-tls-key") {
-		fmt.Println("DEPRECATED flag used: 'timescaledb-tls-key'. This flag will be removed in future versions of tobs. Use helm values file to configure TLS certificate. This option can be configured with either 'timescaledb-single.secrets.certificate' or 'timescaledb-single.secrets.certificateSecretName'")
 	}
 
 	err = i.InstallStack()


### PR DESCRIPTION
<!-- 
Changelog entry

We are using GitHub to generate changelog in each release note. This method takes PR title and uses it as a changelog line. For this reason we ask you to use meaningful PR titles.
-->

Fixing #358

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

Removing deprecated flags.

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
