### PR TITLE
Deploy Prometheus in high availability mode

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -56,7 +56,8 @@ promscale:
   openTelemetry:
     enabled: &otelEnabled true
   # to pass extra args
-  extraArgs: []
+  extraArgs:
+    - "--metrics.high-availability=true"
 
   extraEnv:
     - name: "TOBS_TELEMETRY_INSTALLED_BY"
@@ -133,6 +134,11 @@ kube-prometheus-stack:
       evaluationInterval: "1m"
       # Prometheus metric retention
       retention: 1d
+      # Number of replicas of each shard to deploy for a Prometheus deployment.
+      replicas: 2
+      replicaExternalLabelName: "__replica__"
+      # Promscale requires a cluster label to be present for high availability mode.
+      prometheusExternalLabelName: "cluster"
       # The remote_read spec configuration for Prometheus.
       # ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotereadspec
       remoteRead:


### PR DESCRIPTION
Signed-off-by: Prem Saraswat <prmsrswt@gmail.com>

<!-- 
Changelog entry

We are using GitHub to generate changelog in each release note. This method takes PR title and uses it as a changelog line. For this reason we ask you to use meaningful PR titles.
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

Fixes #351 

This PR configures Prometheus to run 2 replicas with required external labels. It also enables the HA mode in Promscale, so that it doesn't ingest duplicate data.

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
