### PR TITLE
use cert-manager for prometheus-operator admission webhook certificates

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -126,6 +126,12 @@ promscale:
 kube-prometheus-stack:
   enabled: true
   fullnameOverride: "tobs-kube-prometheus"
+
+  prometheusOperator:
+    admissionWebhooks:
+      certManager:
+        enabled: true
+
   prometheus:
     prometheusSpec:
       scrapeInterval: "1m"


### PR DESCRIPTION
<!-- 
Changelog entry

We are using GitHub to generate changelog in each release note. This method takes PR title and uses it as a changelog line. For this reason we ask you to use meaningful PR titles.
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

Since we are reliant on cert-manager for opentelemetry-operator purposes, it might be good to reuse it also for kube-prometheus. This should slightly speed up and simplify startup process.

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
