### PR TITLE
chart: deploy alertmanager in HA mode

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -127,6 +127,10 @@ promscale:
 kube-prometheus-stack:
   enabled: true
   fullnameOverride: "tobs-kube-prometheus"
+  alertmanager:
+    alertmanagerSpec:
+      replicas: 3
+
   prometheus:
     prometheusSpec:
       scrapeInterval: "1m"

--- a/cli/tests/tobs-cli-tests/main_test.go
+++ b/cli/tests/tobs-cli-tests/main_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 	installObs()
 
 	// FIXME(paulfantom): This should be converted into polling for instances
-	time.Sleep(3 * time.Minute)
+	time.Sleep(5 * time.Minute)
 
 	log.Println("starting e2e tests post tobs deployment....")
 	code := m.Run()
@@ -55,11 +55,11 @@ func TestMain(m *testing.M) {
 	uninstallsObs()
 
 	// wait for the uninstall to succeed
-	// this takes 3 mins because in HA mode
+	// this takes 5 mins because in HA mode
 	// we have 2 Prometheus instances to gracefully shutdown
 	// and to avoid flakiness.
 	// FIXME(paulfantom): This should be converted into polling for instances
-	time.Sleep(3 * time.Minute)
+	time.Sleep(5 * time.Minute)
 
 	// TODO(paulfantom): This should be a part of TestUninstall()
 	err = test_utils.CheckPVCSExist(RELEASE_NAME, NAMESPACE)


### PR DESCRIPTION
<!-- 
Changelog entry

We are using GitHub to generate changelog in each release note. This method takes PR title and uses it as a changelog line. For this reason we ask you to use meaningful PR titles.
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

To ensure high-availability of the monitoring stack we should deploy prometheus as well as alertmanager in HA modes. Prometheus HA deployment was accomplished in https://github.com/timescale/tobs/pull/416. This PR is a continuation and ensures alertmanager is also running in HA.

This is also aligning tobs with prometheus-operator project recommendations regarding deployment topology.

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
