### PR TITLE
Remove kube version constraint

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for tobs, The Observability Stack for Kubernetes
 
 type: application
 
-version: 0.11.1
-appVersion: 0.11.1
+version: 0.11.2
+appVersion: 0.11.2
 # TODO(paulfantom): Enable after kubernetes 1.22 reaches EOL (2022-10-28)
 # kubeVersion: ">= 1.23.0"
 dependencies:

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -6,8 +6,8 @@ type: application
 
 version: 0.11.1
 appVersion: 0.11.1
-kubeVersion: ">= 1.23.0"
-
+# TODO(paulfantom): Enable after kubernetes 1.22 reaches EOL (2022-10-28)
+# kubeVersion: ">= 1.23.0"
 dependencies:
   - name: timescaledb-single
     condition: timescaledb-single.enabled

--- a/cli/cmd/version/version.go
+++ b/cli/cmd/version/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TODO(paulfantom): read this from VERSION file in the the repository TLD
-const tobsVersion = "0.11.1"
+const tobsVersion = "0.11.2"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -3,7 +3,7 @@
 set -eu
 
 INSTALLROOT=${INSTALLROOT:-"${HOME}/.local/bin"}
-TOBS_VERSION=${TOBS_VERSION:-0.11.1}
+TOBS_VERSION=${TOBS_VERSION:-0.11.2}
 
 happyexit() {
 	local symlink_msg=""


### PR DESCRIPTION
<!-- 
Changelog entry

We are using GitHub to generate changelog in each release note. This method takes PR title and uses it as a changelog line. For this reason we ask you to use meaningful PR titles.
-->

Removing hard dependency on kubernetes 1.23 as this version is not widely available in multiple clouds. We will reconsider enabling this option in future releases.

Fixing https://github.com/timescale/tobs/issues/440

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
