### PR TITLE
Set default resource requests and limits to tobs deployment

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -134,7 +134,8 @@ jobs:
         env:
           KUBE_VERSION: ${{ matrix.kube-version }}
         run: |
-          make e2e-tests
+          make e2e-tests || :
+          kubectl get pods -A -o wide
 
       - name: Check datasources
         run: make check-datasources

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -44,6 +44,12 @@ timescaledb-single:
       size: 150Gi
     wal:
       size: 20Gi
+  ## TimescaleDB resource requests
+  resources:
+    requests:
+      cpu: 100m
+      memory: 2Gi
+
 
 # Values for configuring the deployment of the Promscale
 # The charts README is at:
@@ -118,8 +124,8 @@ promscale:
     requests:
       # By default this should be enough for a cluster
       # with only a few pods
-      memory: 2Gi
-      cpu: 1
+      memory: 500Mi
+      cpu: 30m
 
 # Enabling Kube-Prometheus will install
 # Grafana & Prometheus into tobs as they
@@ -130,7 +136,26 @@ kube-prometheus-stack:
   alertmanager:
     alertmanagerSpec:
       replicas: 3
-
+      ## AlertManager resource requests
+      resources:
+        limits:
+          memory: 100Mi
+          cpu: 100m
+        requests:
+          memory: 50Mi
+          cpu: 4m
+  prometheusOperator:
+    ## Prometheus sidecar config reloader container resource limits
+    configReloaderCpu: 100m
+    configReloaderMemory: 50Mi
+    ## Prometheus Operator resource requests
+    resources:
+      limits:
+        memory: 200Mi
+        cpu: 100m
+      requests:
+        memory: 100Mi
+        cpu: 10m
   prometheus:
     prometheusSpec:
       scrapeInterval: "1m"
@@ -140,6 +165,12 @@ kube-prometheus-stack:
       retention: 1d
       # Number of replicas of each shard to deploy for a Prometheus deployment.
       replicas: 2
+      ## Prometheus container retention
+      resources:
+        requests:
+          memory: 400Mi
+          cpu: 40m
+
       replicaExternalLabelName: "__replica__"
       # Promscale requires a cluster label to be present for high availability mode.
       prometheusExternalLabelName: "cluster"
@@ -374,6 +405,13 @@ kube-prometheus-stack:
       repository: grafana/grafana
       tag: 9.0.2
       pullPolicy: IfNotPresent
+    resources:
+      limits:
+        cpu: 200m
+        memory: 400Mi
+      requests:
+        cpu: 50m
+        memory: 250Mi
     sidecar:
       datasources:
         enabled: true
@@ -439,17 +477,31 @@ kube-prometheus-stack:
       # Endpoint for integrating jaeger datasource in grafana. This should point to HTTP endpoint, not gRPC.
       promscaleTracesQueryEndPoint: "{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201"
 
-  # By default kube-state-metrics are scraped using
-  # serviceMonitor disable annotation based scraping
   kube-state-metrics:
+    # By default kube-state-metrics are scraped using
+    # serviceMonitor disable annotation based scraping
     prometheusScrape: false
+    resources:
+      limits:
+        cpu: 100m
+        memory: 200Mi
+      requests:
+        cpu: 10m
+        memory: 30Mi
 
-  # By default node-exporter are scraped using
-  # serviceMonitor disable annotation based scraping
   prometheus-node-exporter:
+    # By default node-exporter are scraped using
+    # serviceMonitor disable annotation based scraping
     service:
       annotations:
         prometheus.io/scrape: "false"
+    resources:
+      limits:
+        cpu: 250m
+        memory: 180Mi
+      requests:
+        cpu: 30m
+        memory: 50Mi
 
 # GrafanaDB job config this job pre-configures Grafana with datasources and dashbaords
 grafanaDBJob:
@@ -471,8 +523,15 @@ promlens:
 # If using tobs CLI you can enable otel with --enable-opentelemetry flag
 opentelemetryOperator:
   enabled: *otelEnabled
+  resources:
+    limits:
+      cpu: 50m
+      memory: 260Mi
+    requests:
+      cpu: 5m
+      memory: 130Mi
   collector:
-    # The default otel collector that will be deployed by CLI once
+    # The default otel collector that will be deployed by helm once
     # the otel operator is in running state
     config: |
       receivers:


### PR DESCRIPTION
<!-- 
Changelog entry

We are using GitHub to generate changelog in each release note. This method takes PR title and uses it as a changelog line. For this reason we ask you to use meaningful PR titles.
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

Setting default resource requirements and limits. Closes #154

Adding resource requests to:
- timescaleDB
- promscale
- prometheus (incl. config-reloader)
- alertmanager (incl. config-reloader)
- prometheus-operator
- grafana
- kube-state-metrics
- node_exporter
- otel-operator 

Adding resource limits to:
- alertmanager (incl. config-reloader)
- prometheus-operator
- grafana
- kube-state-metrics
- node_exporter
- otel-operator 

All resource information are largely based on settings from kube-prometheus project (jsonnet one). Resource requirements were lowered to match values noted by running tobs in `kind` cluster as well as values from clusters with longer run time.

Requirements listed in this PR sum up to:
```
mem: 4GB + (# nodes * 50Mi)
cpu: 0.5core + (# nodes * 30milicore)
```

We will need to adjust them when we have more data. However those should be safe for a start.

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)