### PR TITLE
Fix sql datasource

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -136,6 +136,9 @@ jobs:
         run: |
           make e2e-tests
 
+      - name: Check datasources
+        run: make check-datasources
+
   # Added to summarize the matrix
   tests-result:
     name: e2e results

--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,6 @@ load-images:
 helm-install: cert-manager load-images
 	helm dep up chart/
 	helm upgrade --install --wait --timeout 15m test chart/
+
+.PHONY: check-datasources
+	./scripts/check-datasources.sh

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for tobs, The Observability Stack for Kubernetes
 
 type: application
 
-version: 0.11.2
-appVersion: 0.11.2
+version: 0.11.3
+appVersion: 0.11.3
 # TODO(paulfantom): Enable after kubernetes 1.22 reaches EOL (2022-10-28)
 # kubeVersion: ">= 1.23.0"
 dependencies:

--- a/chart/templates/grafana-datasource-job.yaml
+++ b/chart/templates/grafana-datasource-job.yaml
@@ -1,0 +1,62 @@
+{{- $grafana := index .Values "kube-prometheus-stack" "grafana" -}}
+{{- $isDBURI := (ne .Values.promscale.connection.uri "")}}
+{{- if and $grafana.enabled $grafana.timescale.datasource.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-grafana-db
+  namespace: {{ template "tobs.namespace" . }}
+  labels:
+    app: {{ template "tobs.fullname" . }}
+    chart: {{ template "tobs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: {{ $.Chart.Name }}-grafana-db
+        image: postgres:12-alpine
+        volumeMounts:
+        - name: sql-volume
+          mountPath: /add-users.sql
+          subPath: add-users.sql
+        env:
+        - name: PGPORT
+          value: {{ ternary (include "tobs.dburi.port" . ) ($grafana.timescale.database.port | quote ) ($isDBURI) }}
+        - name: PGUSER
+          value: {{ ternary (include "tobs.dburi.user" . ) ($grafana.timescale.adminUser ) ($isDBURI) }}
+          {{ if $isDBURI }}
+        - name: PGPASSWORD
+          value: {{ include "tobs.dburi.password" . }}
+          {{ else }}
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ tpl $grafana.timescale.adminPassSecret $ }}
+              key: PROMSCALE_DB_PASSWORD
+          {{ end }}
+        - name: PGHOST
+          value: {{ ternary (include "tobs.dburi.hostwithoutport" . ) ( tpl $grafana.timescale.database.host $ ) ($isDBURI) }}
+        command: [ 'psql', '-d', {{ ternary (include "tobs.dburi.dbname" . ) ($grafana.timescale.database.dbName ) ($isDBURI) }}, '-f', '/add-users.sql' ]
+        {{ if .Values.grafanaDBJob.resources }}
+        resources:
+          {{ toYaml .Values.grafanaDBJob.resources | nindent 14 }}
+        {{ end }}
+      restartPolicy: OnFailure
+      volumes:
+      - name: sql-volume
+        configMap:
+          name: {{ $.Release.Name }}-grafana-db
+      initContainers:
+      - name: init-db
+        image: busybox:1.28
+        volumeMounts:
+        - name: sql-volume
+          mountPath: /wait-for-ts.sh
+          subPath: wait-for-ts.sh
+        env:
+        - name: PGHOST
+          value: {{ ternary (include "tobs.dburi.hostwithoutport" . ) ( tpl $grafana.timescale.database.host $ ) ($isDBURI) }}
+        command: [ 'sh', '/wait-for-ts.sh' ]
+{{- end -}}

--- a/chart/templates/grafana-datasource-sql.yaml
+++ b/chart/templates/grafana-datasource-sql.yaml
@@ -1,0 +1,47 @@
+{{- $grafana := index .Values "kube-prometheus-stack" "grafana" -}}
+{{- $isDBURI := (ne .Values.promscale.connection.uri "")}}
+{{ if and $grafana.enabled $grafana.timescale.datasource.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-grafana-db
+  namespace: {{ template "tobs.namespace" . }}
+  labels:
+   app: {{ template "tobs.fullname" . }}
+   chart: {{ template "tobs.chart" . }}
+   release: {{ .Release.Name }}
+data:
+   add-users.sql: |-
+    \set ON_ERROR_STOP on
+    DO $$
+      BEGIN
+        CREATE ROLE prom_reader;
+      EXCEPTION WHEN duplicate_object THEN
+        RAISE NOTICE 'role prom_reader already exists, skipping create';
+      END
+    $$;
+    DO $$
+      BEGIN
+        CREATE ROLE {{ $grafana.timescale.datasource.user }} WITH LOGIN PASSWORD '{{ $grafana.timescale.datasource.pass }}';
+      EXCEPTION WHEN duplicate_object THEN
+        RAISE NOTICE 'role {{ $grafana.timescale.datasource.user }} already exists, skipping create';
+      END
+    $$;
+    GRANT prom_reader TO {{ $grafana.timescale.datasource.user }};
+   wait-for-ts.sh: |-
+    echo Checking if ${PGHOST} is up
+    NUM_TIMES_FAILED=0;
+    until nslookup ${PGHOST};
+    do
+      echo Num times failed: ${NUM_TIMES_FAILED}
+      NUM_TIMES_FAILED=$(( $NUM_TIMES_FAILED + 1 ));
+      if [ "${NUM_TIMES_FAILED}" -gt "5" ]
+      then
+        echo Failed 5 times while waiting for ${PGHOST}, exiting
+        exit 1;
+      fi
+      echo Waiting 5 seconds;
+      sleep 5;
+      echo Checking if ${PGHOST} is up
+    done
+{{- end -}}

--- a/chart/templates/timescaledb-toolkit.yaml
+++ b/chart/templates/timescaledb-toolkit.yaml
@@ -1,0 +1,18 @@
+{{- $tsdb := index .Values "timescaledb-single" -}}
+{{ if $tsdb.enabled -}}
+{{- /*
+FIXME(paulfantom): Remove this ConfigMap when timescaleDB images start to be published with toolkit pre-enabled
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-init-scripts
+  namespace: {{ template "tobs.namespace" . }}
+  labels:
+   app: {{ template "tobs.fullname" . }}
+   chart: {{ template "tobs.chart" . }}
+   release: {{ .Release.Name }}
+data:
+  toolkit.sql: |
+    create extension if not exists timescaledb_toolkit
+{{- end -}}

--- a/cli/cmd/version/version.go
+++ b/cli/cmd/version/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TODO(paulfantom): read this from VERSION file in the the repository TLD
-const tobsVersion = "0.11.2"
+const tobsVersion = "0.11.3"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -3,7 +3,7 @@
 set -eu
 
 INSTALLROOT=${INSTALLROOT:-"${HOME}/.local/bin"}
-TOBS_VERSION=${TOBS_VERSION:-0.11.2}
+TOBS_VERSION=${TOBS_VERSION:-0.11.3}
 
 happyexit() {
 	local symlink_msg=""

--- a/scripts/check-datasources.sh
+++ b/scripts/check-datasources.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# TODO(paulfantom): consider using jsonnet for modifications from this script
+
+set -euo pipefail
+
+function query() {
+    local uid="$1"
+    local query="$2"
+    local format="$3"
+
+    local body=$(cat <<-EOM
+{
+    "queries":[
+        {
+            "datasource":{
+                "uid":"$uid"
+            },
+            "refId":"A",
+            "format":"$format",
+            "expr":"$query"
+        }
+    ],
+    "from":"now-5m",
+    "to":"now"
+}
+EOM
+)
+    curl -H "Content-Type: application/json" -X POST -d "$body" "http://${GRAFANA_USER}:${GRAFANA_PASS}@localhost:3000/api/ds/query" 2>/dev/null | jq '.results.A'
+}
+
+
+# Get helm release name
+RELEASE="$(helm list -o json | jq -r '.[0].name')"
+NAMESPACE="$(helm list -o json | jq -r '.[0].namespace')"
+
+# Get grafana credentials
+GRAFANA_USER="admin"
+GRAFANA_PASS="$(kubectl get secret -n "${NAMESPACE}" "${RELEASE}-grafana" -o json | jq -r '.data["admin-password"]' | base64 -d)"
+
+# Cleanup port-forward on exit
+trap 'kill $(jobs -p)' EXIT
+
+# Port-forward to grafana SVC
+kubectl -n "${NAMESPACE}" port-forward svc/test-grafana 3000:80 &
+sleep 5
+
+SQL_QUERY="SELECT * FROM pg_extension WHERE extname = 'timescaledb_toolkit';"
+RESULT_SQL=$(query "c4729dfb8ceeaa0372ef27403a3932695eee995d" "$SQL_QUERY" "table")
+if [ "$(jq 'has("error")' <<< ${RESULT_SQL})" == "true" ]; then
+    echo "GRAFANA SQL DATASOURCE CANNOT QUERY DATA DUE TO:"
+    jq '.error' <<< ${RESULT_SQL}
+    exit 1
+fi
+
+RESULT_PRM=$(query "dc08d25c8f267b054f12002f334e6d3d32a853e4" "ALERTS" "time_series")
+if [ "$(jq 'has("error")' <<< ${RESULT_PRM})" == "true" ]; then
+    echo "GRAFANA PROMQL DATASOURCE CANNOT QUERY DATA DUE TO:"
+    jq '.error' <<< ${RESULT_PRM}
+    exit 1
+fi
+
+echo "All queries passed"


### PR DESCRIPTION
<!-- 
Changelog entry

We are using GitHub to generate changelog in each release note. This method takes PR title and uses it as a changelog line. For this reason we ask you to use meaningful PR titles.
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

Two bugfixes at a price of one:
- Fixing setting SQL datasource by reverting deletion of Job object
- Fixing usage of timescaledb_toolkit as it is still not enabled by default on all dbs.

Since those issues are recurring, I added a rudimentary shell script to check if grafana can query for `timescaledb_toolkit` extension. This check is in shell script as we are approaching refactoring of our test suite and I didn't want to add more complexity to the migration path.

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
