### PR TITLE
.github: add stale bot

### DIFF
--- a/.github/workflows/project-management.yml
+++ b/.github/workflows/project-management.yml
@@ -21,6 +21,20 @@ jobs:
         # PAT token is managed by @paulfantom
         github-token: ${{ secrets.ORG_PROJECT_PAT }}
 
+  stale-issues-handler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          any-of-labels: 'needs-more-info,question'
+          stale-pr-label: 'stale'
+          exempt-all-milestones: true
+          days-before-stale: 30
+          days-before-close: 30
+          stale-issue-message: |
+            This issue went stale because it was not updated in a month. Please consider updating it to improve the quality of the project.
+          close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity.'
+
   update_milestone_on_release:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' 


### PR DESCRIPTION
<!-- 
Changelog entry

We are using GitHub to generate changelog in each release note. This method takes PR title and uses it as a changelog line. For this reason we ask you to use meaningful PR titles.
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

Adding stale bot to handle issues and PRs labeled with either `question` or `needs-more-info`.

The bot will mark issues as stale (noted by `stale` label) after 30 days of no activity and close them after another 30 days.

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
