### PR TITLE
Update trace reference URLs in APM dashboards

### DIFF
--- a/chart/dashboards/apm-home.json
+++ b/chart/dashboards/apm-home.json
@@ -296,7 +296,7 @@
                   {
                     "targetBlank": true,
                     "title": "View trace details",
-                    "url": "/explore?left=%5B%22${__from}%22,%22${__to}%22,%22f78291126102e0f2e841734d1e90250257543042%22,%7B\"query\":\"${__value.raw}\"%7D%5D"
+                    "url": "/explore?orgId=1&left=%7B%22datasource%22:%22f78291126102e0f2e841734d1e90250257543042%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22query%22:%22${__value.raw}%22%7D%5D,%22range%22:%7B%22from%22:%22${__from}%22,%22to%22:%22${__to}%22%7D%7D"
                   }
                 ]
               }

--- a/chart/dashboards/apm-service-overview.json
+++ b/chart/dashboards/apm-service-overview.json
@@ -550,7 +550,7 @@
                   {
                     "targetBlank": true,
                     "title": "View trace details",
-                    "url": "/explore?left=%5B%22${__from}%22,%22${__to}%22,%22f78291126102e0f2e841734d1e90250257543042%22,%7B\"query\":\"${__value.raw}\"%7D%5D"
+                    "url": "/explore?orgId=1&left=%7B%22datasource%22:%22f78291126102e0f2e841734d1e90250257543042%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22query%22:%22${__value.raw}%22%7D%5D,%22range%22:%7B%22from%22:%22${__from}%22,%22to%22:%22${__to}%22%7D%7D"
                   }
                 ]
               }


### PR DESCRIPTION
Update APM dashboards trace reference URLs.

## Description

As the default version of Grafana in tobs is `9.0.2` this requires trace reference URLs to be updated. 

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
