### PR TITLE
github: reconfigure renovate to allow automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,14 @@
 {
   "timezone": "Etc/UTC",
   "extends": [
-    "config:base",
-    "schedule:daily"
+    "config:base"
   ],
+  "schedule": [
+    "every 4 hours"
+  ],
+  "automerge": "true",
+  "automergeType": "pr",
+  "platformAutomerge": "true",
   "dependencyDashboardLabels": ["dependencies"],
   "dependencyDashboardAutoclose": "true",
   "labels": ["dependencies"],


### PR DESCRIPTION
<!-- 
Changelog entry

We are using GitHub to generate changelog in each release note. This method takes PR title and uses it as a changelog line. For this reason we ask you to use meaningful PR titles.
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

This would allow to automatically merge renovate PRs when CI checks are green and there is a required number of positive code reviews.

It's also changing schedule at which renovate should run to every 4 hours instead of once per day.

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
