### PR TITLE
Add timeout to kubectl wait command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ cert-manager: start-kind
 	# Give enough time for a cluster to register new Pods
 	sleep 7
 	# Wait for pods to be up and running
-	kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=cert-manager -n cert-manager
+	kubectl wait --timeout=120s --for=condition=ready pod -l app.kubernetes.io/instance=cert-manager -n cert-manager
 
 .PHONY: load-images
 load-images:  ## Load images into the local kubernetes kind cluster.


### PR DESCRIPTION
## Description

Sometimes when running `make helm-install` will error due to cert-manager not being up in time.  Add a timeout of `120s` to ensure there is enough time for it to start before proceeding.

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
