### PR TITLE
Lock versions of chart dependencies that were missing

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -23,6 +23,6 @@ dependencies:
     version: 37.2.0
     repository: https://prometheus-community.github.io/helm-charts
   - name: opentelemetry-operator
-    condition: opentelemetryOperator.enabled
+    condition: opentelemetry-operator.enabled
     version: 0.9.3
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/chart/docs/upgrades.md
+++ b/chart/docs/upgrades.md
@@ -46,6 +46,13 @@ $$;
 GRANT prom_reader TO <<USERNAME>>;
 ```
 
+### Open-telemetry configuration change in values.yaml
+
+Starting with tobs `0.12.0` the configuration of Open-telemetry has changed
+from `opentelemetryOperator` to `opentelemetry-operator`. If you are using the
+default values in `values.yaml` nothing should be needed.  If you are
+customizing values please make sure you have updated name.
+
 ## Upgrading to 0.11.0
 
 Starting with tobs `0.11.0` we are tackling mostly reliability improvements. One of such improvements is switching grafana database back to dedicated sqlite3 instead of sharing TimescaleDB between grafana and promscale. Sadly this change requires manual intervention from end-users. If you wish to temporarily still use TimescaleDB as a grafana backend, you need to change following value:
@@ -108,7 +115,7 @@ kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheu
             enabled: <value>
         # as this is your custom values.yaml
         # do not forget to change Promscale image to 0.8.0 tag
-        image: timescale/promscale:0.8.0    
+        image: timescale/promscale:0.8.0
         connection:
             # assign the db-password here, the password should be in <release-name>-credentials secret from previous installation
             # with key PATRONI_SUPERUSER_PASSWORD
@@ -117,7 +124,7 @@ kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheu
             uri: <>
         # change service section only if you enabling LoadBalancer type service for Promscale
         service:
-            type: LoadBalancer  
+            type: LoadBalancer
 ```
 4. If you want to enable tracing do not forget to enable `promscale.openTelemetry.enabled` to true and `openTelemetryOperator.enabled` to true.
 5. If you are using Promscale HA with Prometheus HA change the Promscale HA arg from `--high-availability` to `--metrics.high-availability` in `promscale.extraArgs`.
@@ -224,7 +231,7 @@ To migrate data from an old Prometheus instance to a new one follow the steps be
 Scale down the existing Prometheus replicas to 0 so that all the in-memory data is stored in Prometheus persistent volume.
 
 ```
-kubectl scale --replicas=0 deploy/tobs-prometheus-server 
+kubectl scale --replicas=0 deploy/tobs-prometheus-server
 ```
 
 **Note**: Wait for the Prometheus pod to gracefully shut down.

--- a/chart/docs/upgrades.md
+++ b/chart/docs/upgrades.md
@@ -50,7 +50,7 @@ GRANT prom_reader TO <<USERNAME>>;
 
 Starting with tobs `0.12.0` the configuration of Open-telemetry has changed
 from `opentelemetryOperator` to `opentelemetry-operator`. If you are using the
-default values in `values.yaml` nothing should be needed.  If you are
+default values in `values.yaml` nothing should be needed. If you are
 customizing values please make sure you have updated name.
 
 ## Upgrading to 0.11.0

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -19,7 +19,7 @@
 {{- if index .Values "kube-prometheus-stack" "grafana" "enabled" }}
 📈 Grafana
 {{- end }}
-{{- if index .Values "opentelemetryOperator" "enabled" }}
+{{- if index .Values "opentelemetry-operator" "enabled" }}
 🚀 OpenTelemetry
 {{- end }}
 
@@ -64,7 +64,7 @@ NOTE: It may take a few minutes for the LoadBalancer IP to be available.
 {{-   end }}
 {{   if not $prometheus.prometheusSpec.storageSpec -}}
 WARNING! Persistence is disabled on Prometheus server. You will lose your data
-         when the Server pod is terminated. (Data will be persisted in 
+         when the Server pod is terminated. (Data will be persisted in
          TimescaleDB.)
 {{-   end }}
 {{- end }}
@@ -165,7 +165,7 @@ To connect to your database, chose one of these options:
     kubectl exec -it --namespace {{ .Release.Namespace }} ${MASTERPOD} -- psql -U postgres
 {{-   end }}
 {{- end }}
-{{ if .Values.opentelemetryOperator.enabled }}
+{{ if index .Values "opentelemetry-operator" "enabled"}}
 #######################################################################################################################
 🚀  OPENTELEMETRY NOTES:
 #######################################################################################################################

--- a/chart/templates/grafana-datasources-sec.yaml
+++ b/chart/templates/grafana-datasources-sec.yaml
@@ -30,7 +30,7 @@ stringData:
         uid: dc08d25c8f267b054f12002f334e6d3d32a853e4
 {{- end -}}
 
-{{- if .Values.opentelemetryOperator.enabled }}
+{{- if index .Values "opentelemetry-operator" "enabled" }}
       - name: Promscale-Tracing
         type: jaeger
         url: {{ tpl $kubePrometheus.grafana.jaeger.promscaleTracesQueryEndPoint . }}

--- a/chart/templates/otel-auto-instrumentation.yaml
+++ b/chart/templates/otel-auto-instrumentation.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.opentelemetryOperator.enabled -}}
+{{ if (index .Values "opentelemetry-operator" "enabled") }}
 apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:

--- a/chart/templates/otel-auto-instrumentation.yaml
+++ b/chart/templates/otel-auto-instrumentation.yaml
@@ -14,11 +14,11 @@ spec:
     - baggage
     - b3
   python:
-    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:latest
+    image: {{ index .Values "opentelemetry-operator" "instrumentation" "pythonImage" }}
   java:
-    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:latest
+    image: {{ index .Values "opentelemetry-operator" "instrumentation" "javaImage" }}
   nodejs:
-    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:latest
+    image: {{ index .Values "opentelemetry-operator" "instrumentation" "nodejsImage" }}
   sampler:
     type: parentbased_traceidratio
     argument: "0.25"

--- a/chart/templates/otel-collector-service-monitor.yaml
+++ b/chart/templates/otel-collector-service-monitor.yaml
@@ -1,4 +1,4 @@
-{{ if and (.Values.opentelemetryOperator.enabled) (.Values.opentelemetryOperator.collector.config) -}}
+{{ if and (index .Values "opentelemetry-operator" "enabled") (index .Values "opentelemetry-operator" "collector" "config") -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/chart/templates/otel-collector.yaml
+++ b/chart/templates/otel-collector.yaml
@@ -1,4 +1,4 @@
-{{ if and (.Values.opentelemetryOperator.enabled) (.Values.opentelemetryOperator.collector.config) -}}
+{{ if and (index .Values "opentelemetry-operator" "enabled") (index .Values "opentelemetry-operator" "collector" "config") -}}
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
@@ -8,6 +8,6 @@ metadata:
     "helm.sh/hook-weight": "0"
 spec:
   config:
-    {{ tpl (toYaml .Values.opentelemetryOperator.collector.config) $ | nindent 4 }}
+    {{ tpl (toYaml (index .Values "opentelemetry-operator" "collector" "config")) $ | nindent 4 }}
 {{- end -}}
 

--- a/chart/templates/otel-operator-service-monitor.yaml
+++ b/chart/templates/otel-operator-service-monitor.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.opentelemetryOperator.enabled }}
+{{ if (index .Values "opentelemetry-operator" "enabled") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -549,6 +549,10 @@ opentelemetry-operator:
       requests:
         cpu: 5m
         memory: 130Mi
+  instrumentation:
+    pythonImage: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:0.32b0
+    javaImage: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.15.0
+    nodejsImage: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.27.0
   collector:
     # The default otel collector that will be deployed by helm once
     # the otel operator is in running state

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -14,7 +14,7 @@ namespaceOverride: ""
 timescaledb-single:
   # disable the chart if an existing TimescaleDB instance is used
   enabled: &dbEnabled true
-  
+
   # override default helm chart image to use one with newer promscale_extension
   image:
     repository: timescale/timescaledb-ha
@@ -135,6 +135,9 @@ kube-prometheus-stack:
   fullnameOverride: "tobs-kube-prometheus"
   alertmanager:
     alertmanagerSpec:
+      image:
+        repository: quay.io/prometheus/alertmanager
+        tag: v0.24.0
       replicas: 3
       ## AlertManager resource requests
       resources:
@@ -145,9 +148,24 @@ kube-prometheus-stack:
           memory: 50Mi
           cpu: 4m
   prometheusOperator:
-    ## Prometheus sidecar config reloader container resource limits
-    configReloaderCpu: 100m
-    configReloaderMemory: 50Mi
+    image:
+      repository: quay.io/prometheus-operator/prometheus-operator
+      tag: v0.57.0
+      pullPolicy: IfNotPresent
+    ## Prometheus config reloader configuration
+    prometheusConfigReloader:
+      # image to use for config and rule reloading
+      image:
+        repository: quay.io/prometheus-operator/prometheus-config-reloader
+        tag: v0.57.0
+      # resource config for prometheusConfigReloader
+      resources:
+        requests:
+          cpu: 100m
+          memory: 50Mi
+        limits:
+          cpu: 200m
+          memory: 50Mi
     ## Prometheus Operator resource requests
     resources:
       limits:
@@ -158,6 +176,9 @@ kube-prometheus-stack:
         cpu: 10m
   prometheus:
     prometheusSpec:
+      image:
+        repository: quay.io/prometheus/prometheus
+        tag: v2.36.1
       scrapeInterval: "1m"
       scrapeTimeout: "10s"
       evaluationInterval: "1m"
@@ -468,6 +489,10 @@ kube-prometheus-stack:
       promscaleTracesQueryEndPoint: "{{ .Release.Name }}-promscale-connector.{{ .Release.Namespace }}.svc:9201"
 
   kube-state-metrics:
+    image:
+      repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
+      tag: v2.5.0
+      pullPolicy: IfNotPresent
     # By default kube-state-metrics are scraped using
     # serviceMonitor disable annotation based scraping
     prometheusScrape: false
@@ -480,6 +505,10 @@ kube-prometheus-stack:
         memory: 30Mi
 
   prometheus-node-exporter:
+    image:
+      repository: quay.io/prometheus/node-exporter
+      tag: v1.3.1
+      pullPolicy: IfNotPresent
     # By default node-exporter are scraped using
     # serviceMonitor disable annotation based scraping
     service:
@@ -507,15 +536,19 @@ promlens:
 
 # Enable OpenTelemetry Operator
 # If using tobs CLI you can enable otel with --enable-opentelemetry flag
-opentelemetryOperator:
-  enabled: *otelEnabled
-  resources:
-    limits:
-      cpu: 50m
-      memory: 260Mi
-    requests:
-      cpu: 5m
-      memory: 130Mi
+opentelemetry-operator:
+  enabled: true
+  manager:
+    image:
+      repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
+      tag: v0.54.0
+    resources:
+      limits:
+        cpu: 50m
+        memory: 260Mi
+      requests:
+        cpu: 5m
+        memory: 130Mi
   collector:
     # The default otel collector that will be deployed by helm once
     # the otel operator is in running state


### PR DESCRIPTION
Added the following images versions
- opentelemetry-opertaor
- kube-state-metrics
- node-exporter
- alertmanager
- prometheus-operator
- prometheus

Changed `opentelemetryOperator` to `opentelemetry-operator` in `values.yaml` so we can support passing values into the opentelemetry-operator Helm chart.

Updated opentelemetry-operator Helm chart from `0.9.2` -> `0.9.3`

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
