### PR TITLE
Update timescaledb-ha image to work with promscale extension

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -18,7 +18,7 @@ timescaledb-single:
   # override default helm chart image to use one with newer promscale_extension
   image:
     repository: timescale/timescaledb-ha
-    tag: pg14.3-ts2.7.0-p0
+    tag: pg14.4-ts2.7.2-p0
     pullPolicy: IfNotPresent
 
   # create only a ClusterIP service


### PR DESCRIPTION
With the upgrade to Promscale 0.13.0 Helm chart it seems we are no longer compatible with the timescaledb-ha image we ship with timescaledb-single Helm chart.  This PR updates the version from `pg14.3-ts2.7.0-p0` -> `pg14.4-ts2.7.2-p0`

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
