### PR TITLE
.github: separate updating helm values from helm charts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,12 @@
     {
       "addLabels": ["helm"],
       "groupName": "helm charts",
-      "matchManagers": ["helmv3", "helm-values"]
+      "matchManagers": ["helmv3"]
+    },
+    {
+      "addLabels": ["helm"],
+      "groupName": "helm values",
+      "matchManagers": ["helm-values"]
     },
     {
       "addLabels": ["github_actions"],


### PR DESCRIPTION
<!-- 
Changelog entry

We are using GitHub to generate changelog in each release note. This method takes PR title and uses it as a changelog line. For this reason we ask you to use meaningful PR titles.
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

By separating helm chart updates from helm values updates we can still have automatic updates for container images regardless of changes carried by the helm charts.

By example instead of getting one PR like https://github.com/timescale/tobs/pull/515 which updates container images and otel-operator helm chart, we should get 2 PRs - one for image updates and one for otel-operator helm chart. This in turn allows us to still update images regardless of issues with otel-operator helm chart.

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
