### PR TITLE
Correct secret name for lookup() function

### DIFF
--- a/chart/templates/timescaledb-grafana-datasource.yaml
+++ b/chart/templates/timescaledb-grafana-datasource.yaml
@@ -15,7 +15,7 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/resource-policy": keep
 {{- if .Release.IsUpgrade }}
-data: {{ (lookup "v1" "Secret" .Release.Namespace "custom-init-scripts").data }}
+data: {{ (lookup "v1" "Secret" .Release.Namespace "custom-secret-scripts").data }}
 {{ else }}
 stringData:
 {{- $pass := ternary (((($kubePrometheus.grafana).timescale).datasource).pass) (randAlphaNum 16) (ne ((($kubePrometheus.grafana).timescale).datasource).pass "") }}


### PR DESCRIPTION

## Description

There would have been an issue during the Helm upgrade process where the `lookup` function inside the template would have looked at the incorrect secret.  This was set to look at `custom-init-scripts` but it should be `custom-secret-scripts`.

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
