### PR TITLE
Setup connection to external TimescaleDB

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,10 @@ jobs:
           make start-kind
           make cert-manager
 
+      - name: Start timescaledb-single helm chart install
+        run: |
+          make timescaledb-single
+
       - name: Wait for cluster to finish bootstraping
         run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
 

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,22 @@ helm-upgrade: cert-manager
 lint:  ## Lint helm chart using ct (chart-testing).
 	ct lint --config ct.yaml
 
+.PHONY: timescaledb-single
+timescaledb-single:
+
+.PHONY: timescaledb-single
+timescaledb-single: ## This is a phony target that is used to install the timescaledb-single chart.
+	kubectl create ns timescaledb
+	helm repo add timescaledb 'https://raw.githubusercontent.com/timescale/helm-charts/main/charts/repo/'
+	helm install test --wait --timeout 15m \
+		timescaledb/timescaledb-single \
+		--namespace=timescaledb \
+		--set replicaCount=1 \
+		--set image.tag=pg14.4-ts2.7.2-p0 \
+		--set loadBalancer.enabled=false \
+		--set secrets.credentials.PATRONI_SUPERUSER_PASSWORD=test123 \
+		--set secrets.credentials.PATRONI_admin_PASSWORD=test123
+
 .PHONY: e2e
 e2e:  ## Run e2e installation tests using ct (chart-testing).
 	ct install --config ct.yaml

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
 - tracing
 - opentelemetry
 
-version: 13.1.0
+version: 13.3.0
 
 # TODO(paulfantom): Enable after kubernetes 1.22 reaches EOL (2022-10-28)
 # kubeVersion: ">= 1.23.0"

--- a/chart/README.md
+++ b/chart/README.md
@@ -121,13 +121,17 @@ The chart has the following properties in the `values.yaml` file:
 
 ## TimescaleDB
 
-| Parameter                                 | Description                                       | Default             |
-|-------------------------------------------|---------------------------------------------------|---------------------|
-| `timescaledb-single.enabled`              | If false TimescaleDB will not be created          | `true`              |
-| `timescaledb-single.image.tag`            | Docker image tag to use for TimescaleDB           | `pg12-ts2.1-latest` |
-| `timescaledb-single.loadBalancer.enabled` | Create a LB for the DB instead of a ClusterIP     | `false`             |
-| `timescaledb-single.replicaCount`         | Number of pods for DB, set to 3 for HA            | `1`                 |
-| `timescaledb-single.backup.enabled`       | TimescaleDB backup option by default set to false | `false`             |
+| Parameter                                      | Description                                       | Default             |
+|------------------------------------------------|---------------------------------------------------|---------------------|
+| `timescaledb-single.enabled`                     | If false TimescaleDB will not be created          | `true`                |
+| `timescaledb-single.image.tag`                   | Docker image tag to use for TimescaleDB           | `pg14.4-ts2.7.2-p0`   |
+| `timescaledb-single.loadBalancer.enabled`        | Create a LB for the DB instead of a ClusterIP     | `false`               |
+| `timescaledb-single.replicaCount`                | Number of pods for DB, set to 3 for HA            | `1`                   |
+| `timescaledb-single.backup.enabled`              | TimescaleDB backup option by default set to false | `false`               |
+| `timescaledb-single.persistentVolumes.data.size` | Size of the volume for the database               | `150Gi`               |
+| `timescaledb-single.persistentVolumes.wal.size`  | Size of the volume for the WAL disk               | `20Gi`                |
+| `resources.requests.cpu`                         | Resource request for cpu                          | `100m`                |
+| `resources.requests.memory`                      | Resource request for memory                       | `2Gi`                 |
 
 ### Additional configuration for TimescaleDB
 
@@ -169,6 +173,7 @@ The Promscale is configured to connect to the TimescaleDB instance deployed with
 But it can be configured to connect to [any TimescaleDB host](#configuring-an-external-timescaledb), and expose whichever port you like.
 For more details about how to configure the Promscale please see the
 [Helm chart directory](https://github.com/timescale/promscale/tree/master/deploy/helm-chart) of the [Promscale](https://github.com/timescale/promscale) repo.
+
 
 ## Kube-Prometheus
 

--- a/chart/ci/externaldb-values.yaml
+++ b/chart/ci/externaldb-values.yaml
@@ -1,0 +1,38 @@
+# This file is based on the ci/default-values.yml. The values has been modified to
+# connect to an externally provisioned TimescaleDB instance. Only resource requests
+# are nullified to allow starting the stack on github action runner and prevent
+# issues related to pod scheduling due to insufficient host resources.
+
+timescaledb-single:
+  enabled: false
+
+promscale:
+  connectionSecretName: ""
+  connection:
+    uri: "postgres://postgres:test123@test.timescaledb.svc:5432/postgres"
+  resources: null
+
+kube-prometheus-stack:
+  alertmanager:
+    alertmanagerSpec:
+      replicas: 1
+      resources: null
+  prometheusOperator:
+    prometheusConfigReloader:
+      resources: null
+    resources: null
+  prometheus:
+    prometheusSpec:
+      replicas: 1
+      resources: null
+  grafana:
+    envValueFrom: null
+    resources: null
+  kube-state-metrics:
+    resources: null
+  prometheus-node-exporter:
+    resources: null
+
+opentelemetry-operator:
+  manager:
+    resources: null

--- a/chart/templates/timescaledb-grafana-datasource.yaml
+++ b/chart/templates/timescaledb-grafana-datasource.yaml
@@ -1,6 +1,6 @@
 {{- $kubePrometheus := index .Values "kube-prometheus-stack" -}}
 {{- $tsdb := index .Values "timescaledb-single" -}}
-{{ if and $tsdb.enabled $kubePrometheus.grafana.enabled ((($kubePrometheus.grafana).timescale).datasource).enabled -}}
+{{- if and $tsdb.enabled $kubePrometheus.grafana.enabled ((($kubePrometheus.grafana).timescale).datasource).enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/docs/tobs-external-db.md
+++ b/docs/tobs-external-db.md
@@ -1,0 +1,57 @@
+# Connect tobs to an external TimescaleDB
+
+## Issue
+
+In the past it wasn't straight forward to connect a tobs provisioned Promscale
+instance to a non-tobs provisioned TimescaleDB instance.  This documentation
+should provide best practices in making this work pretty seamless.
+
+## Connecting using a Postgres URI
+
+It's now possible to set a connection URI in the Promscale configuration in
+tobs.  To do so you just need to edit your Helm `values.yaml` or set the value
+in the CLI.  Here is a more complete example:
+[example-values.yaml](../chart/ci/externaldb-values.yaml)
+
+```yaml
+timescaledb-single:
+  enabled: false
+
+promscale:
+  connectionSecretName: ""
+  connection:
+    uri: "postgres://user@pass:host.svc.local:5432/database"
+
+kube-prometheus-stack:
+  grafana:
+    envValueFrom: null
+```
+
+If you have Grafana enabled this will not setup the datasource connection for
+you automatically.  If you wish to have that connection you will need to do so
+manually for now. The following sql will need to be ran on the TimescaleDB
+instance after Promscale has setup the connection and is running. Just replace
+the `<grafana role>` with the name of the role you wish to give it.
+
+```sql
+\set ON_ERROR_STOP on
+DO $$
+  BEGIN
+    CREATE ROLE prom_reader;
+  EXCEPTION WHEN duplicate_object THEN
+    RAISE NOTICE 'role prom_reader already exists, skipping create';
+  END
+$$;
+DO $$
+  BEGIN
+    CREATE ROLE <grafana role> WITH LOGIN PASSWORD 'pass';
+  EXCEPTION WHEN duplicate_object THEN
+    RAISE NOTICE 'role <grafana role> already exists, skipping create';
+  END
+$$;
+GRANT prom_reader TO <grafana role>;
+```
+
+For any other information for creating roles and users please look at the
+documentation
+[here](https://docs.timescale.com/promscale/latest/roles-and-permissions/#example-permissions)


### PR DESCRIPTION
## Description

Create a way to connect to and setup Grafana to query an external TimescaleDB if it's not provisioned by tobs.

You can now easily install tobs to connect to an external (to tobs) TimescaleDB.  This can be achieved by setting `timescaledb-single.enabled=false`, setting the password for the TimescaleDB `postgres` role in `promscale.connection.password`, and the host URI for timescale in `promscale.connection.host`.

This at minimum will setup Promscale and the Grafana datasource connections correctly to the external TimescaleDB.

## Type of change

*What type of changes does your code introduce to tobs? Put an `x` in the box that apply.*

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
