### PR TITLE
chart: use connectionSecretName to set promscale connection to db

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
 - tracing
 - opentelemetry
 
-version: 12.0.2
+version: 12.1.0
 
 # TODO(paulfantom): Enable after kubernetes 1.22 reaches EOL (2022-10-28)
 # kubeVersion: ">= 1.23.0"

--- a/chart/templates/connection-secret-job.yaml
+++ b/chart/templates/connection-secret-job.yaml
@@ -1,5 +1,10 @@
 {{- $db := index .Values "timescaledb-single" -}}
-{{- if and $db.enabled (eq .Values.promscale.connectionSecretName "") (eq .Values.promscale.connection.password "") (.Release.IsInstall) -}}
+{{- if and
+    $db.enabled
+    (eq .Values.promscale.connectionSecretName "tobs-promscale-connection")
+    (eq .Values.promscale.connection.password "")
+    (eq .Values.promscale.connection.uri "")
+-}}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -47,6 +52,26 @@ subjects:
   name: {{ .Release.Name }}-promscale-initializer-sa
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.promscale.connectionSecretName }}
+  namespace: {{ template "tobs.namespace" . }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    app: {{ template "tobs.fullname" . }}
+    chart: {{ template "tobs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+stringData:
+  PROMSCALE_DB_PORT: "5432"
+  PROMSCALE_DB_HOST: "{{ .Release.Name }}.{{ .Release.Namespace }}.svc"
+  PROMSCALE_DB_NAME: "postgres"
+  PROMSCALE_DB_USER: "postgres"
+  PROMSCALE_DB_SSL_MODE: "require"
+  PROMSCALE_DB_PASSWORD: "PLACEHOLDER"
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-connection-initializer
@@ -64,7 +89,7 @@ data:
       sleep 1
     done
     PASS=$(kubectl get secret --namespace {{ template "tobs.namespace" . }} {{ .Release.Name }}-credentials -o json | jq -r '.data["PATRONI_SUPERUSER_PASSWORD"]')
-    kubectl get secret --namespace {{ template "tobs.namespace" . }} {{ .Release.Name }}-promscale -o json | jq --arg PASS "$PASS" '.data["PROMSCALE_DB_PASSWORD"]=$PASS' | kubectl apply -f -
+    kubectl get secret --namespace {{ template "tobs.namespace" . }} {{ .Values.promscale.connectionSecretName }} -o json | jq --arg PASS "$PASS" '.data["PROMSCALE_DB_PASSWORD"]=$PASS' | kubectl apply -f -
 ---
 apiVersion: batch/v1
 kind: Job

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -87,35 +87,9 @@ promscale:
   # If you are providing your own secret name, do
   # not forget to configure at below connectionSecretName
 
-  # selector used to provision your own Secret containing connection details
-  # Use this option with caution
-
   # if you are adding a conn string here do not forget
   # to add the same for kube-prometheus.grafana.timescale.adminPassSecret
-  connectionSecretName: ""
-
-  ## Note:
-
-  # If you using tobs deploy TimescaleDB do not configure below
-  # any connection details below as tobs will take care of it.
-
-  # connection details to connect to a target db
-  connection:
-    # Database connection settings. If `uri` is not
-    # set then the specific user, pass, host, port and
-    # sslMode properties are used.
-    uri: ""
-    # the db name in which the metrics will be stored
-    dbName: &metricDB postgres
-    # user to connect to TimescaleDB with
-    user: postgres
-    # empty password string will be populated automatically with a database password
-    password: ""
-    # Host name (templated) of the database instance, default
-    # to service created in timescaledb-single
-    host: &dbHost "{{ .Release.Name }}.{{ .Release.Namespace }}.svc"
-    port: 5432
-    sslMode: require
+  connectionSecretName: "tobs-promscale-connection"
 
   # Promscale deployment resource requests
   resources:
@@ -301,11 +275,11 @@ kube-prometheus-stack:
         user: grafana
         # leaving password empty will cause helm to generate a random password
         pass: ""
-        dbName: *metricDB
+        dbName: postgres
         sslMode: require
         # By default the url/host is set to the db instance deployed
         # with this chart
-        host: *dbHost
+        host: "{{ .Release.Name }}.{{ .Release.Namespace }}.svc"
         port: 5432
     jaeger:
       # Endpoint for integrating jaeger datasource in grafana. This should point to HTTP endpoint, not gRPC.


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Embedding mechanism for propagating database password in promscale helm chart may have been a mistake as it casues issues like https://github.com/timescale/promscale/issues/1474. To keep similar logic we can move it into tobs and use `connectionSecretName`.

#### Which issue this PR fixes

It allows us to fix https://github.com/timescale/promscale/issues/1474. Also it paves a path to fix what was reported in https://iobeam.slack.com/archives/C03L8NYLUF7/p1660571016688299

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/tobs)