### PR TITLE
restrict service account token from being accessed

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
 - tracing
 - opentelemetry
 
-version: 12.1.0
+version: 12.1.1
 
 # TODO(paulfantom): Enable after kubernetes 1.22 reaches EOL (2022-10-28)
 # kubeVersion: ">= 1.23.0"

--- a/chart/templates/connection-secret-job.yaml
+++ b/chart/templates/connection-secret-job.yaml
@@ -8,6 +8,9 @@
 ---
 apiVersion: v1
 kind: ServiceAccount
+#automountServiceAccountToken is needed to since password-initializer.sh is
+#using kubectl to access the Kubernetes api
+automountServiceAccountToken: true
 metadata:
   name: {{ .Release.Name }}-promscale-initializer-sa
   namespace: {{ template "tobs.namespace" . }}


### PR DESCRIPTION
#### What this PR does / why we need it

Access to service account token should be restricted 


#### Which issue this PR fixes

- fixes #461, https://github.com/timescale/promscale/pull/1559

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/tobs)