### PR TITLE
.github: reconfigure renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,7 @@
   "dependencyDashboardAutoclose": "true",
   "labels": ["dependencies"],
   "ignoreDeps": ["k8s.io/client-go"],
+  "bumpVersion": true,
   "regexManagers": [
     {
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
@@ -23,7 +24,7 @@
     },
     {
       "fileMatch": ["^Makefile$"],
-      "matchStrings": ["CERT_MANAGER_VERSION\\s?=\\s(?<currentValue>.*?)\\n"],
+      "matchStrings": ["CERT_MANAGER_VERSION\\s\\?=\\s(?<currentValue>.*?)\\n"],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "cert-manager/cert-manager"
     }
@@ -32,12 +33,7 @@
     {
       "addLabels": ["helm"],
       "groupName": "helm charts",
-      "matchManagers": ["helmv3"]
-    },
-    {
-      "addLabels": ["helm"],
-      "groupName": "helm values",
-      "matchManagers": ["helm-values"]
+      "matchManagers": ["helmv3", "helm-values"]
     },
     {
       "addLabels": ["github_actions"],


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

1) Fixing cert-manager updates via renovate
2) Allowing renovate to bump chart version when doing dependency chart updates
3) Groupping helm values updates with helm dependencies updates to allow chart version updates. This is needed as https://github.com/renovatebot/renovate/issues/8231 is not complete.
4) Testing our CI gating of version updates.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart Version bumped
- [ ] [CLA signed](https://cla-assistant.io/timescale/tobs)