### PR TITLE
.github: make renovate always bump helm chart minor version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
   "dependencyDashboardAutoclose": "true",
   "labels": ["dependencies"],
   "ignoreDeps": ["k8s.io/client-go"],
-  "bumpVersion": "true",
+  "bumpVersion": "minor",
   "regexManagers": [
     {
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Judging by https://github.com/timescale/tobs/pull/551 our renovate configuration is not correct. According to https://docs.renovatebot.com/configuration-options/#bumpversion value of `true` is not allowed and we need to choose which semver component to bump automatically. This PR should fix the issue and we can use https://github.com/timescale/tobs/pull/551 as a testbed.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart Version bumped
- [ ] [CLA signed](https://cla-assistant.io/timescale/tobs)