### PR TITLE
Bump promscale helm chart to 13.0.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
 - tracing
 - opentelemetry
 
-version: 13.3.0
+version: 14.0.0
 
 # TODO(paulfantom): Enable after kubernetes 1.22 reaches EOL (2022-10-28)
 # kubeVersion: ">= 1.23.0"
@@ -26,7 +26,7 @@ dependencies:
     repository: https://charts.timescale.com
   - name: promscale
     condition: promscale.enabled
-    version: 0.13.0
+    version: 13.0.0
     repository: https://charts.timescale.com
   - name: kube-prometheus-stack
     condition: kube-prometheus-stack.enabled

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -64,7 +64,10 @@ timescaledb-single:
 #   https://github.com/timescale/promscale/tree/master/helm-chart
 promscale:
   enabled: true
-  image: timescale/promscale:0.13.0
+  image:
+    repository: timescale/promscale
+    tag: 0.13.0
+    pullPolicy: IfNotPresent
   # to pass extra args
   extraArgs:
     - "--metrics.high-availability=true"

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -7,6 +7,26 @@ Firstly upgrade the helm repo to pull the latest available tobs helm chart. We a
 ```
 helm repo update
 ```
+
+## Upgrading 13.x to 14.x
+
+### promscale image configuration change
+
+Starting with tobs `14.0.0` the configuration of the Promscale image has changed.
+If you are not overriding the Promscale version you can ignore this.  If you
+are explicitly overriding the version you will need to follow the new image/tag
+format
+
+```
+promscale:
+  enabled: true
+  image:
+    repository: timescale/promscale
+    tag: 0.13.0
+    pullPolicy: IfNotPresent
+```
+
+
 ## Upgrading 12.0.x to 13.0.0
 
 ### kube-prometheus-stack name override removed


### PR DESCRIPTION
#### What this PR does / why we need it

Update Promscale Helm chart to the latest version `13.0.0` and update relevant documentation


#### Which issue this PR fixes

- fixes #509 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/tobs)