### PR TITLE
Force helm-s3 to download the correct version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             mkdir -p chart_release
             helm dep up chart
             helm package chart -d chart_release/
-            helm plugin install https://github.com/hypnoglow/helm-s3.git
+            helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.13.0
             helm repo add tscharts s3://charts.timescale.com
             helm s3 push chart_release/* tscharts --acl public-read --relative --dry-run
 


### PR DESCRIPTION
#### What this PR does / why we need it

helm-s3 currently has a bug when trying to install the plugin https://github.com/hypnoglow/helm-s3/issues/203

This PR applies a work around for now.

#### Which issue this PR fixes

- fixes #

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/tobs)