### PR TITLE
chart: bump promscale version to 0.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,12 +61,12 @@ timescaledb-single:
 .PHONY: timescaledb-single
 timescaledb-single: ## This is a phony target that is used to install the timescaledb-single chart.
 	kubectl create ns timescaledb
-	helm repo add timescaledb 'https://raw.githubusercontent.com/timescale/helm-charts/main/charts/repo/'
+	-helm repo add timescaledb 'https://charts.timescale.com'
+	helm repo update timescaledb
 	helm install test --wait --timeout 15m \
 		timescaledb/timescaledb-single \
 		--namespace=timescaledb \
 		--set replicaCount=1 \
-		--set image.tag=pg14.4-ts2.7.2-p0 \
 		--set loadBalancer.enabled=false \
 		--set secrets.credentials.PATRONI_SUPERUSER_PASSWORD=test123 \
 		--set secrets.credentials.PATRONI_admin_PASSWORD=test123

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,14 +15,14 @@ keywords:
   - tracing
   - opentelemetry
 
-version: 14.4.0
+version: 14.5.0
 
 # TODO(paulfantom): Enable after kubernetes 1.22 reaches EOL (2022-10-28)
 # kubeVersion: ">= 1.23.0"
 dependencies:
   - name: timescaledb-single
     condition: timescaledb-single.enabled
-    version: 0.14.4
+    version: 0.16.1
     repository: https://charts.timescale.com
   - name: promscale
     condition: promscale.enabled

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -59,8 +59,8 @@ timescaledb-single:
       repository: quay.io/prometheuscommunity/postgres-exporter
       tag: v0.11.1
 
-  # Specifies whether ServiceMonitor for Prometheus operator should be created
-  serviceMonitor:
+  # Specifies whether PodMonitor for Prometheus operator should be created
+  podMonitor:
     enabled: true
 
 # Values for configuring the deployment of the Promscale
@@ -70,7 +70,7 @@ promscale:
   enabled: true
   image:
     repository: timescale/promscale
-    tag: 0.13.0
+    tag: 0.14.0
     pullPolicy: IfNotPresent
   # to pass extra args
   extraArgs:


### PR DESCRIPTION
Signed-off-by: Paweł Krupa (paulfantom) <pawel@krupa.net.pl>

<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR is mainly bumping promscale to 0.14.0. Additionally it is using latest timescale helm chart and unlocking timescaledb image version used in tests (this way we only need to bump image in the upstream helm chart).

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/tobs)