### PR TITLE
do not force prometheus into reading recent data from promscale

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - tracing
   - opentelemetry
 
-version: 14.9.0
+version: 14.10.0
 
 # TODO(paulfantom): Enable after kubernetes 1.22 reaches EOL (2022-10-28)
 # kubeVersion: ">= 1.23.0"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -178,7 +178,7 @@ kube-prometheus-stack:
       remoteRead:
         # - {protocol}://{host}:{port}/{endpoint}
         - url: "http://{{ .Release.Name }}-promscale.{{ .Release.Namespace }}.svc:9201/read"
-          readRecent: true
+          readRecent: false
 
       # The remote_write spec configuration for Prometheus.
       # ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotewritespec


### PR DESCRIPTION
This should allow retreiving data from prometheus even when promscale is down and thus increasing overal reliability of the stack.

Signed-off-by: Paweł Krupa (paulfantom) <pawel@krupa.net.pl>

<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Recent outage surfaced that when promscale is down, our whole monitoring system can go down due to misconfigured remote_read. Before change from this PR prometheus ALWAYS wanted to get data from promscale when querying data or computing recording rules. This in turn created a single point of failure even in a setup with prometheus in HA. This PR is fixing this major issue and allows prometheus to be used as a buffer when promscale is down.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/tobs)