### PR TITLE
Bump timescaledb-single helm chart to 0.18.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,13 +12,13 @@ keywords:
   - monitoring
   - tracing
   - opentelemetry
-version: 16.1.0
+version: 16.2.0
 # TODO(paulfantom): Enable after kubernetes 1.22 reaches EOL (2022-10-28)
 # kubeVersion: ">= 1.23.0"
 dependencies:
   - name: timescaledb-single
     condition: timescaledb-single.enabled
-    version: 0.17.0
+    version: 0.18.0
     repository: https://charts.timescale.com
   - name: promscale
     condition: promscale.enabled


### PR DESCRIPTION
#### What this PR does / why we need it

* Update [timescaledb-single](https://github.com/timescale/helm-charts/tree/main/charts/timescaledb-single) Helm chart to `0.18.0`

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/tobs)