### PR TITLE
Set stats_temp_directory to tmp directory

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - monitoring
   - tracing
   - opentelemetry
-version: 17.16.0
+version: 17.17.0
 # TODO(paulfantom): Enable after kubernetes 1.22 reaches EOL (2022-10-28)
 # kubeVersion: ">= 1.23.0"
 dependencies:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -44,6 +44,8 @@ timescaledb-single:
             bgwriter_lru_maxpages: 100000
             # synchronous_commit: "off"
             shared_preload_libraries: timescaledb,pg_stat_statements,pg_stat_monitor,pg_stat_kcache
+            # TODO: stats_temp_directory was deprectated on PG15, we should remove it when the DB upgrades.
+            stats_temp_directory: /tmp/pg_stat_temp
   # TimescaleDB PVC sizes
   persistentVolumes:
     data:


### PR DESCRIPTION
#### What this PR does / why we need it

Moves the stats temporary file outside the data directory to improve
disk performance.

According to the docs:

```
stats_temp_directory (string)

Sets the directory to store temporary statistics data in. This can be
a path relative to the data directory or an absolute path. The default
is pg_stat_tmp. Pointing this at a RAM-based file system will decrease
physical I/O requirements and can lead to improved performance. This
parameter can only be set in the postgresql.conf file or on the server
command line.
```

PG15 rewrote the statistics collector, from that version onward the
statistics are no longer stored in files and the `stats_temp_directory`
config options was deprecated. Once the DB upgrades to PG15 this setting
can be removed.

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/tobs)