### PR TITLE
upgrade kube-prometheus-stack to latest version

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - monitoring
   - tracing
   - opentelemetry
-version: 18.3.0
+version: 19.0.0
 # TODO(paulfantom): Enable after kubernetes 1.22 reaches EOL (2022-10-28)
 # kubeVersion: ">= 1.23.0"
 dependencies:
@@ -26,7 +26,7 @@ dependencies:
     repository: https://charts.timescale.com
   - name: kube-prometheus-stack
     condition: kube-prometheus-stack.enabled
-    version: 41.9.1
+    version: 42.2.0
     repository: https://prometheus-community.github.io/helm-charts
   - name: opentelemetry-operator
     condition: opentelemetry-operator.enabled

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -116,7 +116,8 @@ kube-prometheus-stack:
   alertmanager:
     alertmanagerSpec:
       image:
-        repository: quay.io/prometheus/alertmanager
+        registry: quay.io
+        repository: prometheus/alertmanager
         tag: v0.24.0
       replicas: 3
       ## AlertManager resource requests
@@ -129,14 +130,16 @@ kube-prometheus-stack:
           cpu: 4m
   prometheusOperator:
     image:
-      repository: quay.io/prometheus-operator/prometheus-operator
+      registry: quay.io
+      repository: prometheus-operator/prometheus-operator
       tag: v0.61.1
       pullPolicy: IfNotPresent
     ## Prometheus config reloader configuration
     prometheusConfigReloader:
       # image to use for config and rule reloading
       image:
-        repository: quay.io/prometheus-operator/prometheus-config-reloader
+        registry: quay.io
+        repository: prometheus-operator/prometheus-config-reloader
         tag: v0.61.1
       # resource config for prometheusConfigReloader
       resources:
@@ -157,8 +160,9 @@ kube-prometheus-stack:
   prometheus:
     prometheusSpec:
       image:
-        repository: quay.io/prometheus/prometheus
-        tag: v2.40.4
+        registry: quay.io
+        repository: prometheus/prometheus
+        tag: v2.40.5
       scrapeInterval: "1m"
       scrapeTimeout: "10s"
       evaluationInterval: "1m"
@@ -267,7 +271,7 @@ kube-prometheus-stack:
     # TODO(paulfantom): remove with kube-prometheus bump
     image:
       repository: grafana/grafana
-      tag: 9.3.0
+      tag: 9.3.1
       pullPolicy: IfNotPresent
     resources:
       limits:

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -8,6 +8,19 @@ Firstly upgrade the helm repo to pull the latest available tobs helm chart. We a
 helm repo update
 ```
 
+## Upgrading from 18.x to 19.x
+
+There is a breaking change in [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-41x-to-42x).
+This will add a new configuration option `global.imageRegistry` along with adding
+a `registry` configuration to all `image` objects.
+
+```yaml
+    image:
+      registry: quay.io
+      repository: prometheus/alertmanager
+      tag: v0.24.0
+```
+
 ## Upgrading from 17.x to 18.x
 
 To get the best performance out of promscale we recommend to query it directly. Since tobs is already shipping grafana datasource configured this way, there is no need to configure `remote_read` option in prometheus. This is a breaking change for people using `remote_read` option. If you need to use `remote_read` option, you can still add it back by putting the following code snippet into your `values.yaml` file.
@@ -35,6 +48,7 @@ Additionally, to prevent data duplication, we are disabling by default
 ability to scrape endpoints using prometheus label annotations. If you wish
 to continue using this option, you need to explicitly set the following
 option:
+
 ```yaml
 kube-prometheus-stack:
   prometheus:


### PR DESCRIPTION
#### What this PR does / why we need it

Updating `kube-prometheus-stack` to the latest version `v42.2.0`.  Which is meant to fix issues with PR's #657 & #665 

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #665 
- fixes #657 

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/tobs)