### PR TITLE
Update timescaledb-ha image to fix Patroni errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ timescaledb: ## This is a phony target that is used to install the timescaledb-s
 	helm install test --wait --timeout 15m \
 		timescaledb/timescaledb-single \
 		--namespace=timescaledb \
+		--version 0.24.1 \
 		--set replicaCount=1 \
 		--set secrets.credentials.PATRONI_SUPERUSER_PASSWORD="temporarypassword" \
 		--set secrets.credentials.PATRONI_admin_PASSWORD="temporarypassword" \

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - monitoring
   - tracing
   - opentelemetry
-version: 19.0.0
+version: 19.1.0
 # TODO(paulfantom): Enable after kubernetes 1.22 reaches EOL (2022-10-28)
 # kubeVersion: ">= 1.23.0"
 dependencies:

--- a/chart/scripts/test-metrics.sh
+++ b/chart/scripts/test-metrics.sh
@@ -47,13 +47,13 @@ EOF
 )
 
 testset="$genericTests"
-if [ $FEATURE_KUBE_PROMETHEUS -eq 1 ]; then
+if [ "$FEATURE_KUBE_PROMETHEUS" -eq 1 ]; then
   testset="$kubePrometheusTests,$testset"
 fi
-if [ $FEATURE_PROMSCALE -eq 1 ]; then
+if [ "$FEATURE_PROMSCALE" -eq 1 ]; then
   testset="$promscaleTests,$testset"
 fi
-if [ $FEATURE_TIMESCALEDB -eq 1 ]; then
+if [ "$FEATURE_TIMESCALEDB" -eq 1 ]; then
   testset="$timescaleTests,$testset"
 fi
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,7 +13,7 @@ timescaledb-single:
   # override default helm chart image to use one with newer promscale_extension
   image:
     repository: timescale/timescaledb-ha
-    tag: pg14.5-ts2.8.1-p2
+    tag: pg14.6-ts2.8.1-patroni-static-primary-p3
     pullPolicy: IfNotPresent
   env:
     - name: TSTUNE_PROFILE
@@ -67,9 +67,9 @@ timescaledb-single:
       repository: quay.io/prometheuscommunity/postgres-exporter
       tag: v0.11.1
     args:
-    # Disabling collecting database size statistics as this can be expensive
-    # and some of this data is also provided via node_exporter.
-    - "--no-collector.database"
+      # Disabling collecting database size statistics as this can be expensive
+      # and some of this data is also provided via node_exporter.
+      - "--no-collector.database"
   # Specifies whether PodMonitor for Prometheus operator should be created
   podMonitor:
     enabled: true
@@ -184,39 +184,39 @@ kube-prometheus-stack:
       ruleSelectorNilUsesHelmValues: false
       ruleNamespaceSelector:
         matchExpressions:
-        - key: tobs/excluded
-          operator: DoesNotExist
+          - key: tobs/excluded
+            operator: DoesNotExist
       ruleSelector:
         matchExpressions:
-        - key: tobs/excluded
-          operator: DoesNotExist
+          - key: tobs/excluded
+            operator: DoesNotExist
       serviceMonitorSelectorNilUsesHelmValues: false
       serviceMonitorSelector:
         matchExpressions:
-        - key: tobs/excluded
-          operator: DoesNotExist
+          - key: tobs/excluded
+            operator: DoesNotExist
       serviceMonitorNamespaceSelector:
         matchExpressions:
-        - key: tobs/excluded
-          operator: DoesNotExist
+          - key: tobs/excluded
+            operator: DoesNotExist
       podMonitorSelectorNilUsesHelmValues: false
       podMonitorSelector:
         matchExpressions:
-        - key: tobs/excluded
-          operator: DoesNotExist
+          - key: tobs/excluded
+            operator: DoesNotExist
       podMonitorNamespaceSelector:
         matchExpressions:
-        - key: tobs/excluded
-          operator: DoesNotExist
+          - key: tobs/excluded
+            operator: DoesNotExist
       probeSelectorNilUsesHelmValues: false
       probeSelector:
         matchExpressions:
-        - key: tobs/excluded
-          operator: DoesNotExist
+          - key: tobs/excluded
+            operator: DoesNotExist
       probeNamespaceSelector:
         matchExpressions:
-        - key: tobs/excluded
-          operator: DoesNotExist
+          - key: tobs/excluded
+            operator: DoesNotExist
       # The remote_read spec configuration for Prometheus.
       # ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#remotereadspec
       # remoteRead:


### PR DESCRIPTION
#### What this PR does / why we need it
This will update the `timescale/timescaledb-ha` image to use the `static-primary` based container image.  This is to work around the Patroni warning messages that spam the Timescaledb logs.

This will be a temporary work around until the [timescaledb-ha](https://github.com/timescale/timescaledb-docker-ha) conrtainer image can be updated with the latest version of Patroni [2.1.5](https://github.com/zalando/patroni/releases/tag/v2.1.5)

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes https://github.com/timescale/helm-charts/issues/492
- fixes https://github.com/timescale/helm-charts/issues/405
- fixes #672 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/tobs)